### PR TITLE
Modify test.sh to work with more than one database instance.

### DIFF
--- a/test.expected
+++ b/test.expected
@@ -1,1152 +1,1152 @@
 
 Chapter 1
-{$n} a,b,d
-{0} 'def',1.1,1
-{1} 'def',1.1,4
-{2} 'mno',4.4,2
-{$n} a,b,d
-{0} 'def',1.1,1
-{1} 'def',1.1,4
-{2} 'mno',4.4,2
-{$n} a,b,d
-{0} 'def',1.1,1
-{1} 'def',1.1,4
-{2} 'mno',4.4,2
-{$n} a,b,d
-{0} 'def',1.1,1
-{1} 'def',1.1,4
-{2} 'mno',4.4,2
-{$n} a,b,d
-{0} 'def',1.1,1
-{1} 'def',1.1,4
-{2} 'mno',4.4,2
-{$n} a,b,d
-{0} 'def',1.1,1
-{1} 'def',1.1,4
-{2} 'mno',4.4,2
-{$n} a,b,d
-{0} 'def',1.1,1
-{1} 'def',1.1,4
-{2} 'mno',4.4,2
-{$n} a,b,i,d,j
-{0} 'def',1.1,1,1,1
-{1} 'def',1.1,1,4,4
-{2} 'mno',4.4,4,2,2
-{$n} a,b,i,d,j
-{0} 'def',1.1,1,1,1
-{1} 'def',1.1,1,4,4
-{2} 'mno',4.4,4,2,2
-{$n} a,b,i,d,j
-{0} 'def',1.1,1,1,1
-{1} 'def',1.1,1,4,4
-{2} 'mno',4.4,4,2,2
-{$n} a,b,i,d,j
-{0} 'def',1.1,1,1,1
-{1} 'def',1.1,1,4,4
-{2} 'mno',4.4,4,2,2
-{$n} a,b,i,d,j
-{0} 'def',1.1,1,1,1
-{1} 'def',1.1,1,4,4
-{2} 'mno',4.4,4,2,2
-{$n} a,b,i,d,j
-{0} 'def',1.1,1,1,1
-{1} 'def',1.1,1,4,4
-{2} 'mno',4.4,4,2,2
+a,b,d
+'def',1.1,1
+'def',1.1,4
+'mno',4.4,2
+a,b,d
+'def',1.1,1
+'def',1.1,4
+'mno',4.4,2
+a,b,d
+'def',1.1,1
+'def',1.1,4
+'mno',4.4,2
+a,b,d
+'def',1.1,1
+'def',1.1,4
+'mno',4.4,2
+a,b,d
+'def',1.1,1
+'def',1.1,4
+'mno',4.4,2
+a,b,d
+'def',1.1,1
+'def',1.1,4
+'mno',4.4,2
+a,b,d
+'def',1.1,1
+'def',1.1,4
+'mno',4.4,2
+a,b,i,d,j
+'def',1.1,1,1,1
+'def',1.1,1,4,4
+'mno',4.4,4,2,2
+a,b,i,d,j
+'def',1.1,1,1,1
+'def',1.1,1,4,4
+'mno',4.4,4,2,2
+a,b,i,d,j
+'def',1.1,1,1,1
+'def',1.1,1,4,4
+'mno',4.4,4,2,2
+a,b,i,d,j
+'def',1.1,1,1,1
+'def',1.1,1,4,4
+'mno',4.4,4,2,2
+a,b,i,d,j
+'def',1.1,1,1,1
+'def',1.1,1,4,4
+'mno',4.4,4,2,2
+a,b,i,d,j
+'def',1.1,1,1,1
+'def',1.1,1,4,4
+'mno',4.4,4,2,2
 
 Chapter 2
-{$n} c,d,b
-{0} 'def',1,1.1
-{1} 'def',4,1.1
-{2} 'mno',2,4.4
-{$n} c,d,b
-{0} 'def',1,1.1
-{1} 'def',4,1.1
-{2} 'mno',2,4.4
-{$n} c,d,b
-{0} 'def',1,1.1
-{1} 'def',4,1.1
-{2} 'mno',2,4.4
-{$n} c,d,b
-{0} 'def',1,1.1
-{1} 'def',4,1.1
-{2} 'mno',2,4.4
-{$n} c,d,b
-{0} 'def',1,1.1
-{1} 'def',4,1.1
-{2} 'mno',2,4.4
-{$n} c,d,b
-{0} 'def',1,1.1
-{1} 'def',4,1.1
-{2} 'mno',2,4.4
-{$n} c,d,b
-{0} 'def',1,1.1
-{1} 'def',4,1.1
-{2} 'mno',2,4.4
-{$n} c,d,j,b,i
-{0} 'def',1,1,1.1,1
-{1} 'def',4,4,1.1,1
-{2} 'mno',2,2,4.4,4
-{$n} c,d,j,b,i
-{0} 'def',1,1,1.1,1
-{1} 'def',4,4,1.1,1
-{2} 'mno',2,2,4.4,4
-{$n} c,d,j,b,i
-{0} 'def',1,1,1.1,1
-{1} 'def',4,4,1.1,1
-{2} 'mno',2,2,4.4,4
-{$n} c,d,j,b,i
-{0} 'def',1,1,1.1,1
-{1} 'def',4,4,1.1,1
-{2} 'mno',2,2,4.4,4
-{$n} c,d,j,b,i
-{0} 'def',1,1,1.1,1
-{1} 'def',4,4,1.1,1
-{2} 'mno',2,2,4.4,4
-{$n} c,d,j,b,i
-{0} 'def',1,1,1.1,1
-{1} 'def',4,4,1.1,1
-{2} 'mno',2,2,4.4,4
+c,d,b
+'def',1,1.1
+'def',4,1.1
+'mno',2,4.4
+c,d,b
+'def',1,1.1
+'def',4,1.1
+'mno',2,4.4
+c,d,b
+'def',1,1.1
+'def',4,1.1
+'mno',2,4.4
+c,d,b
+'def',1,1.1
+'def',4,1.1
+'mno',2,4.4
+c,d,b
+'def',1,1.1
+'def',4,1.1
+'mno',2,4.4
+c,d,b
+'def',1,1.1
+'def',4,1.1
+'mno',2,4.4
+c,d,b
+'def',1,1.1
+'def',4,1.1
+'mno',2,4.4
+c,d,j,b,i
+'def',1,1,1.1,1
+'def',4,4,1.1,1
+'mno',2,2,4.4,4
+c,d,j,b,i
+'def',1,1,1.1,1
+'def',4,4,1.1,1
+'mno',2,2,4.4,4
+c,d,j,b,i
+'def',1,1,1.1,1
+'def',4,4,1.1,1
+'mno',2,2,4.4,4
+c,d,j,b,i
+'def',1,1,1.1,1
+'def',4,4,1.1,1
+'mno',2,2,4.4,4
+c,d,j,b,i
+'def',1,1,1.1,1
+'def',4,4,1.1,1
+'mno',2,2,4.4,4
+c,d,j,b,i
+'def',1,1,1.1,1
+'def',4,4,1.1,1
+'mno',2,2,4.4,4
 
 Chapter 3
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
 
 Chapter 4
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
 
 Chapter 5
-{$n} i,a,b,c
-{0} 1,'def',1.1,'def'
-{1} 2,'ghi',2.2,'mno'
-{2} 3,'jkl',3.3,null
-{3} 4,'mno',4.4,'def'
-{$n} i,a,b,c
-{0} 1,'def',1.1,'def'
-{1} 2,'ghi',2.2,'mno'
-{2} 3,'jkl',3.3,null
-{3} 4,'mno',4.4,'def'
-{$n} i,a,b,c
-{0} 1,'def',1.1,'def'
-{1} 2,'ghi',2.2,'mno'
-{2} 3,'jkl',3.3,null
-{3} 4,'mno',4.4,'def'
-{$n} i,a,b,c
-{0} 1,'def',1.1,'def'
-{1} 2,'ghi',2.2,'mno'
-{2} 3,'jkl',3.3,null
-{3} 4,'mno',4.4,'def'
-{$n} i,a,b,c
-{0} 1,'def',1.1,'def'
-{1} 2,'ghi',2.2,'mno'
-{2} 3,'jkl',3.3,null
-{3} 4,'mno',4.4,'def'
-{$n} i,a,b,c
-{0} 1,'def',1.1,'def'
-{1} 2,'ghi',2.2,'mno'
-{2} 3,'jkl',3.3,null
-{3} 4,'mno',4.4,'def'
-{$n} i,a,b,c
-{0} 1,'def',1.1,'def'
-{1} 2,'ghi',2.2,'mno'
-{2} 3,'jkl',3.3,null
-{3} 4,'mno',4.4,'def'
-{$n} i,a,b,c,j
-{0} 1,'def',1.1,'def',1
-{1} 2,'ghi',2.2,'mno',2
-{2} 3,'jkl',3.3,null,3
-{3} 4,'mno',4.4,'def',4
-{$n} i,a,b,c,j
-{0} 1,'def',1.1,'def',1
-{1} 2,'ghi',2.2,'mno',2
-{2} 3,'jkl',3.3,null,3
-{3} 4,'mno',4.4,'def',4
-{$n} i,a,b,c,j
-{0} 1,'def',1.1,'def',1
-{1} 2,'ghi',2.2,'mno',2
-{2} 3,'jkl',3.3,null,3
-{3} 4,'mno',4.4,'def',4
-{$n} i,a,b,c,j
-{0} 1,'def',1.1,'def',1
-{1} 2,'ghi',2.2,'mno',2
-{2} 3,'jkl',3.3,null,3
-{3} 4,'mno',4.4,'def',4
+i,a,b,c
+1,'def',1.1,'def'
+2,'ghi',2.2,'mno'
+3,'jkl',3.3,null
+4,'mno',4.4,'def'
+i,a,b,c
+1,'def',1.1,'def'
+2,'ghi',2.2,'mno'
+3,'jkl',3.3,null
+4,'mno',4.4,'def'
+i,a,b,c
+1,'def',1.1,'def'
+2,'ghi',2.2,'mno'
+3,'jkl',3.3,null
+4,'mno',4.4,'def'
+i,a,b,c
+1,'def',1.1,'def'
+2,'ghi',2.2,'mno'
+3,'jkl',3.3,null
+4,'mno',4.4,'def'
+i,a,b,c
+1,'def',1.1,'def'
+2,'ghi',2.2,'mno'
+3,'jkl',3.3,null
+4,'mno',4.4,'def'
+i,a,b,c
+1,'def',1.1,'def'
+2,'ghi',2.2,'mno'
+3,'jkl',3.3,null
+4,'mno',4.4,'def'
+i,a,b,c
+1,'def',1.1,'def'
+2,'ghi',2.2,'mno'
+3,'jkl',3.3,null
+4,'mno',4.4,'def'
+i,a,b,c,j
+1,'def',1.1,'def',1
+2,'ghi',2.2,'mno',2
+3,'jkl',3.3,null,3
+4,'mno',4.4,'def',4
+i,a,b,c,j
+1,'def',1.1,'def',1
+2,'ghi',2.2,'mno',2
+3,'jkl',3.3,null,3
+4,'mno',4.4,'def',4
+i,a,b,c,j
+1,'def',1.1,'def',1
+2,'ghi',2.2,'mno',2
+3,'jkl',3.3,null,3
+4,'mno',4.4,'def',4
+i,a,b,c,j
+1,'def',1.1,'def',1
+2,'ghi',2.2,'mno',2
+3,'jkl',3.3,null,3
+4,'mno',4.4,'def',4
 
 Chapter 6
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{1} 2,'mno','ghi',2.2
-{2} 3,null,'jkl',3.3
-{3} 4,'def','mno',4.4
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{1} 2,'mno','ghi',2.2
-{2} 3,null,'jkl',3.3
-{3} 4,'def','mno',4.4
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{1} 2,'mno','ghi',2.2
-{2} 3,null,'jkl',3.3
-{3} 4,'def','mno',4.4
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{1} 2,'mno','ghi',2.2
-{2} 3,null,'jkl',3.3
-{3} 4,'def','mno',4.4
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{1} 2,'mno','ghi',2.2
-{2} 3,null,'jkl',3.3
-{3} 4,'def','mno',4.4
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{1} 2,'mno','ghi',2.2
-{2} 3,null,'jkl',3.3
-{3} 4,'def','mno',4.4
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{1} 2,'mno','ghi',2.2
-{2} 3,null,'jkl',3.3
-{3} 4,'def','mno',4.4
-{$n} d,c,j,a,b
-{0} 1,'def',1,'def',1.1
-{1} 2,'mno',2,'ghi',2.2
-{2} 3,null,3,'jkl',3.3
-{3} 4,'def',4,'mno',4.4
-{$n} d,c,j,a,b
-{0} 1,'def',1,'def',1.1
-{1} 2,'mno',2,'ghi',2.2
-{2} 3,null,3,'jkl',3.3
-{3} 4,'def',4,'mno',4.4
-{$n} d,c,j,a,b
-{0} 1,'def',1,'def',1.1
-{1} 2,'mno',2,'ghi',2.2
-{2} 3,null,3,'jkl',3.3
-{3} 4,'def',4,'mno',4.4
-{$n} d,c,j,a,b
-{0} 1,'def',1,'def',1.1
-{1} 2,'mno',2,'ghi',2.2
-{2} 3,null,3,'jkl',3.3
-{3} 4,'def',4,'mno',4.4
-{$n} d,c,j,a,b
-{0} 1,'def',1,'def',1.1
-{1} 2,'mno',2,'ghi',2.2
-{2} 3,null,3,'jkl',3.3
-{3} 4,'def',4,'mno',4.4
-{$n} d,c,j,a,b
-{0} 1,'def',1,'def',1.1
-{1} 2,'mno',2,'ghi',2.2
-{2} 3,null,3,'jkl',3.3
-{3} 4,'def',4,'mno',4.4
+d,c,a,b
+1,'def','def',1.1
+2,'mno','ghi',2.2
+3,null,'jkl',3.3
+4,'def','mno',4.4
+d,c,a,b
+1,'def','def',1.1
+2,'mno','ghi',2.2
+3,null,'jkl',3.3
+4,'def','mno',4.4
+d,c,a,b
+1,'def','def',1.1
+2,'mno','ghi',2.2
+3,null,'jkl',3.3
+4,'def','mno',4.4
+d,c,a,b
+1,'def','def',1.1
+2,'mno','ghi',2.2
+3,null,'jkl',3.3
+4,'def','mno',4.4
+d,c,a,b
+1,'def','def',1.1
+2,'mno','ghi',2.2
+3,null,'jkl',3.3
+4,'def','mno',4.4
+d,c,a,b
+1,'def','def',1.1
+2,'mno','ghi',2.2
+3,null,'jkl',3.3
+4,'def','mno',4.4
+d,c,a,b
+1,'def','def',1.1
+2,'mno','ghi',2.2
+3,null,'jkl',3.3
+4,'def','mno',4.4
+d,c,j,a,b
+1,'def',1,'def',1.1
+2,'mno',2,'ghi',2.2
+3,null,3,'jkl',3.3
+4,'def',4,'mno',4.4
+d,c,j,a,b
+1,'def',1,'def',1.1
+2,'mno',2,'ghi',2.2
+3,null,3,'jkl',3.3
+4,'def',4,'mno',4.4
+d,c,j,a,b
+1,'def',1,'def',1.1
+2,'mno',2,'ghi',2.2
+3,null,3,'jkl',3.3
+4,'def',4,'mno',4.4
+d,c,j,a,b
+1,'def',1,'def',1.1
+2,'mno',2,'ghi',2.2
+3,null,3,'jkl',3.3
+4,'def',4,'mno',4.4
+d,c,j,a,b
+1,'def',1,'def',1.1
+2,'mno',2,'ghi',2.2
+3,null,3,'jkl',3.3
+4,'def',4,'mno',4.4
+d,c,j,a,b
+1,'def',1,'def',1.1
+2,'mno',2,'ghi',2.2
+3,null,3,'jkl',3.3
+4,'def',4,'mno',4.4
 
 Chapter 7
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{$n} d,c,j,a,b
-{0} 4,'def',4,'mno',4.4
-{$n} d,c,j,a,b
-{0} 4,'def',4,'mno',4.4
-{$n} d,c,j,a,b
-{0} 4,'def',4,'mno',4.4
-{$n} d,c,j,a,b
-{0} 4,'def',4,'mno',4.4
-{$n} d,c,j,a,b
-{0} 4,'def',4,'mno',4.4
-{$n} d,c,j,a,b
-{0} 4,'def',4,'mno',4.4
+d,c,a,b
+1,'def','def',1.1
+d,c,a,b
+1,'def','def',1.1
+d,c,a,b
+1,'def','def',1.1
+d,c,a,b
+1,'def','def',1.1
+d,c,a,b
+1,'def','def',1.1
+d,c,a,b
+1,'def','def',1.1
+d,c,a,b
+1,'def','def',1.1
+d,c,j,a,b
+4,'def',4,'mno',4.4
+d,c,j,a,b
+4,'def',4,'mno',4.4
+d,c,j,a,b
+4,'def',4,'mno',4.4
+d,c,j,a,b
+4,'def',4,'mno',4.4
+d,c,j,a,b
+4,'def',4,'mno',4.4
+d,c,j,a,b
+4,'def',4,'mno',4.4
 
 Chapter 8
-{$n} j,c,d,b
-{0} 1,'def',1,1.1
-{$n} j,c,d,b
-{0} 1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
 
 Chapter 9
-{$n} a,b,d
-{0} 'def',1.1,1
-{1} 'def',1.1,4
-{2} 'mno',4.4,2
-{$n} a,b,d
-{0} 'def',1.1,1
-{1} 'def',1.1,4
-{2} 'mno',4.4,2
-{$n} a,b,d
-{0} 'def',1.1,1
-{1} 'def',1.1,4
-{2} 'mno',4.4,2
-{$n} a,b,d
-{0} 'def',1.1,1
-{1} 'def',1.1,4
-{2} 'mno',4.4,2
-{$n} a,b,d
-{0} 'def',1.1,1
-{1} 'def',1.1,4
-{2} 'mno',4.4,2
-{$n} a,b,d
-{0} 'def',1.1,1
-{1} 'def',1.1,4
-{2} 'mno',4.4,2
-{$n} a,b,d
-{0} 'def',1.1,1
-{1} 'def',1.1,4
-{2} 'mno',4.4,2
-{$n} a,b,i,d,j
-{0} 'def',1.1,1,1,1
-{1} 'def',1.1,1,4,4
-{2} 'mno',4.4,4,2,2
-{$n} a,b,i,d,j
-{0} 'def',1.1,1,1,1
-{1} 'def',1.1,1,4,4
-{2} 'mno',4.4,4,2,2
-{$n} a,b,i,d,j
-{0} 'def',1.1,1,1,1
-{1} 'def',1.1,1,4,4
-{2} 'mno',4.4,4,2,2
-{$n} a,b,i,d,j
-{0} 'def',1.1,1,1,1
-{1} 'def',1.1,1,4,4
-{2} 'mno',4.4,4,2,2
-{$n} a,b,i,d,j
-{0} 'def',1.1,1,1,1
-{1} 'def',1.1,1,4,4
-{2} 'mno',4.4,4,2,2
-{$n} a,b,i,d,j
-{0} 'def',1.1,1,1,1
-{1} 'def',1.1,1,4,4
-{2} 'mno',4.4,4,2,2
+a,b,d
+'def',1.1,1
+'def',1.1,4
+'mno',4.4,2
+a,b,d
+'def',1.1,1
+'def',1.1,4
+'mno',4.4,2
+a,b,d
+'def',1.1,1
+'def',1.1,4
+'mno',4.4,2
+a,b,d
+'def',1.1,1
+'def',1.1,4
+'mno',4.4,2
+a,b,d
+'def',1.1,1
+'def',1.1,4
+'mno',4.4,2
+a,b,d
+'def',1.1,1
+'def',1.1,4
+'mno',4.4,2
+a,b,d
+'def',1.1,1
+'def',1.1,4
+'mno',4.4,2
+a,b,i,d,j
+'def',1.1,1,1,1
+'def',1.1,1,4,4
+'mno',4.4,4,2,2
+a,b,i,d,j
+'def',1.1,1,1,1
+'def',1.1,1,4,4
+'mno',4.4,4,2,2
+a,b,i,d,j
+'def',1.1,1,1,1
+'def',1.1,1,4,4
+'mno',4.4,4,2,2
+a,b,i,d,j
+'def',1.1,1,1,1
+'def',1.1,1,4,4
+'mno',4.4,4,2,2
+a,b,i,d,j
+'def',1.1,1,1,1
+'def',1.1,1,4,4
+'mno',4.4,4,2,2
+a,b,i,d,j
+'def',1.1,1,1,1
+'def',1.1,1,4,4
+'mno',4.4,4,2,2
 
 Chapter 10
-{$n} c,d,b
-{0} 'def',1,1.1
-{1} 'def',4,1.1
-{2} 'mno',2,4.4
-{$n} c,d,b
-{0} 'def',1,1.1
-{1} 'def',4,1.1
-{2} 'mno',2,4.4
-{$n} c,d,b
-{0} 'def',1,1.1
-{1} 'def',4,1.1
-{2} 'mno',2,4.4
-{$n} c,d,b
-{0} 'def',1,1.1
-{1} 'def',4,1.1
-{2} 'mno',2,4.4
-{$n} c,d,b
-{0} 'def',1,1.1
-{1} 'def',4,1.1
-{2} 'mno',2,4.4
-{$n} c,d,b
-{0} 'def',1,1.1
-{1} 'def',4,1.1
-{2} 'mno',2,4.4
-{$n} c,d,b
-{0} 'def',1,1.1
-{1} 'def',4,1.1
-{2} 'mno',2,4.4
-{$n} c,d,j,b,i
-{0} 'def',1,1,1.1,1
-{1} 'def',4,4,1.1,1
-{2} 'mno',2,2,4.4,4
-{$n} c,d,j,b,i
-{0} 'def',1,1,1.1,1
-{1} 'def',4,4,1.1,1
-{2} 'mno',2,2,4.4,4
-{$n} c,d,j,b,i
-{0} 'def',1,1,1.1,1
-{1} 'def',4,4,1.1,1
-{2} 'mno',2,2,4.4,4
-{$n} c,d,j,b,i
-{0} 'def',1,1,1.1,1
-{1} 'def',4,4,1.1,1
-{2} 'mno',2,2,4.4,4
-{$n} c,d,j,b,i
-{0} 'def',1,1,1.1,1
-{1} 'def',4,4,1.1,1
-{2} 'mno',2,2,4.4,4
-{$n} c,d,j,b,i
-{0} 'def',1,1,1.1,1
-{1} 'def',4,4,1.1,1
-{2} 'mno',2,2,4.4,4
+c,d,b
+'def',1,1.1
+'def',4,1.1
+'mno',2,4.4
+c,d,b
+'def',1,1.1
+'def',4,1.1
+'mno',2,4.4
+c,d,b
+'def',1,1.1
+'def',4,1.1
+'mno',2,4.4
+c,d,b
+'def',1,1.1
+'def',4,1.1
+'mno',2,4.4
+c,d,b
+'def',1,1.1
+'def',4,1.1
+'mno',2,4.4
+c,d,b
+'def',1,1.1
+'def',4,1.1
+'mno',2,4.4
+c,d,b
+'def',1,1.1
+'def',4,1.1
+'mno',2,4.4
+c,d,j,b,i
+'def',1,1,1.1,1
+'def',4,4,1.1,1
+'mno',2,2,4.4,4
+c,d,j,b,i
+'def',1,1,1.1,1
+'def',4,4,1.1,1
+'mno',2,2,4.4,4
+c,d,j,b,i
+'def',1,1,1.1,1
+'def',4,4,1.1,1
+'mno',2,2,4.4,4
+c,d,j,b,i
+'def',1,1,1.1,1
+'def',4,4,1.1,1
+'mno',2,2,4.4,4
+c,d,j,b,i
+'def',1,1,1.1,1
+'def',4,4,1.1,1
+'mno',2,2,4.4,4
+c,d,j,b,i
+'def',1,1,1.1,1
+'def',4,4,1.1,1
+'mno',2,2,4.4,4
 
 Chapter 11
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
 
 Chapter 12
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
 
 Chapter 13
-{$n} i,a,b,c
-{0} 1,'def',1.1,'def'
-{1} 2,'ghi',2.2,'mno'
-{2} 3,'jkl',3.3,null
-{3} 4,'mno',4.4,'def'
-{$n} i,a,b,c
-{0} 1,'def',1.1,'def'
-{1} 2,'ghi',2.2,'mno'
-{2} 3,'jkl',3.3,null
-{3} 4,'mno',4.4,'def'
-{$n} i,a,b,c
-{0} 1,'def',1.1,'def'
-{1} 2,'ghi',2.2,'mno'
-{2} 3,'jkl',3.3,null
-{3} 4,'mno',4.4,'def'
-{$n} i,a,b,c
-{0} 1,'def',1.1,'def'
-{1} 2,'ghi',2.2,'mno'
-{2} 3,'jkl',3.3,null
-{3} 4,'mno',4.4,'def'
-{$n} i,a,b,c
-{0} 1,'def',1.1,'def'
-{1} 2,'ghi',2.2,'mno'
-{2} 3,'jkl',3.3,null
-{3} 4,'mno',4.4,'def'
-{$n} i,a,b,c
-{0} 1,'def',1.1,'def'
-{1} 2,'ghi',2.2,'mno'
-{2} 3,'jkl',3.3,null
-{3} 4,'mno',4.4,'def'
-{$n} i,a,b,c
-{0} 1,'def',1.1,'def'
-{1} 2,'ghi',2.2,'mno'
-{2} 3,'jkl',3.3,null
-{3} 4,'mno',4.4,'def'
-{$n} i,a,b,c,j
-{0} 1,'def',1.1,'def',1
-{1} 2,'ghi',2.2,'mno',2
-{2} 3,'jkl',3.3,null,3
-{3} 4,'mno',4.4,'def',4
-{$n} i,a,b,c,j
-{0} 1,'def',1.1,'def',1
-{1} 2,'ghi',2.2,'mno',2
-{2} 3,'jkl',3.3,null,3
-{3} 4,'mno',4.4,'def',4
-{$n} i,a,b,c,j
-{0} 1,'def',1.1,'def',1
-{1} 2,'ghi',2.2,'mno',2
-{2} 3,'jkl',3.3,null,3
-{3} 4,'mno',4.4,'def',4
-{$n} i,a,b,c,j
-{0} 1,'def',1.1,'def',1
-{1} 2,'ghi',2.2,'mno',2
-{2} 3,'jkl',3.3,null,3
-{3} 4,'mno',4.4,'def',4
+i,a,b,c
+1,'def',1.1,'def'
+2,'ghi',2.2,'mno'
+3,'jkl',3.3,null
+4,'mno',4.4,'def'
+i,a,b,c
+1,'def',1.1,'def'
+2,'ghi',2.2,'mno'
+3,'jkl',3.3,null
+4,'mno',4.4,'def'
+i,a,b,c
+1,'def',1.1,'def'
+2,'ghi',2.2,'mno'
+3,'jkl',3.3,null
+4,'mno',4.4,'def'
+i,a,b,c
+1,'def',1.1,'def'
+2,'ghi',2.2,'mno'
+3,'jkl',3.3,null
+4,'mno',4.4,'def'
+i,a,b,c
+1,'def',1.1,'def'
+2,'ghi',2.2,'mno'
+3,'jkl',3.3,null
+4,'mno',4.4,'def'
+i,a,b,c
+1,'def',1.1,'def'
+2,'ghi',2.2,'mno'
+3,'jkl',3.3,null
+4,'mno',4.4,'def'
+i,a,b,c
+1,'def',1.1,'def'
+2,'ghi',2.2,'mno'
+3,'jkl',3.3,null
+4,'mno',4.4,'def'
+i,a,b,c,j
+1,'def',1.1,'def',1
+2,'ghi',2.2,'mno',2
+3,'jkl',3.3,null,3
+4,'mno',4.4,'def',4
+i,a,b,c,j
+1,'def',1.1,'def',1
+2,'ghi',2.2,'mno',2
+3,'jkl',3.3,null,3
+4,'mno',4.4,'def',4
+i,a,b,c,j
+1,'def',1.1,'def',1
+2,'ghi',2.2,'mno',2
+3,'jkl',3.3,null,3
+4,'mno',4.4,'def',4
+i,a,b,c,j
+1,'def',1.1,'def',1
+2,'ghi',2.2,'mno',2
+3,'jkl',3.3,null,3
+4,'mno',4.4,'def',4
 
 Chapter 14
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{1} 2,'mno','ghi',2.2
-{2} 3,null,'jkl',3.3
-{3} 4,'def','mno',4.4
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{1} 2,'mno','ghi',2.2
-{2} 3,null,'jkl',3.3
-{3} 4,'def','mno',4.4
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{1} 2,'mno','ghi',2.2
-{2} 3,null,'jkl',3.3
-{3} 4,'def','mno',4.4
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{1} 2,'mno','ghi',2.2
-{2} 3,null,'jkl',3.3
-{3} 4,'def','mno',4.4
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{1} 2,'mno','ghi',2.2
-{2} 3,null,'jkl',3.3
-{3} 4,'def','mno',4.4
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{1} 2,'mno','ghi',2.2
-{2} 3,null,'jkl',3.3
-{3} 4,'def','mno',4.4
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{1} 2,'mno','ghi',2.2
-{2} 3,null,'jkl',3.3
-{3} 4,'def','mno',4.4
-{$n} d,c,j,a,b
-{0} 1,'def',1,'def',1.1
-{1} 2,'mno',2,'ghi',2.2
-{2} 3,null,3,'jkl',3.3
-{3} 4,'def',4,'mno',4.4
-{$n} d,c,j,a,b
-{0} 1,'def',1,'def',1.1
-{1} 2,'mno',2,'ghi',2.2
-{2} 3,null,3,'jkl',3.3
-{3} 4,'def',4,'mno',4.4
-{$n} d,c,j,a,b
-{0} 1,'def',1,'def',1.1
-{1} 2,'mno',2,'ghi',2.2
-{2} 3,null,3,'jkl',3.3
-{3} 4,'def',4,'mno',4.4
-{$n} d,c,j,a,b
-{0} 1,'def',1,'def',1.1
-{1} 2,'mno',2,'ghi',2.2
-{2} 3,null,3,'jkl',3.3
-{3} 4,'def',4,'mno',4.4
-{$n} d,c,j,a,b
-{0} 1,'def',1,'def',1.1
-{1} 2,'mno',2,'ghi',2.2
-{2} 3,null,3,'jkl',3.3
-{3} 4,'def',4,'mno',4.4
-{$n} d,c,j,a,b
-{0} 1,'def',1,'def',1.1
-{1} 2,'mno',2,'ghi',2.2
-{2} 3,null,3,'jkl',3.3
-{3} 4,'def',4,'mno',4.4
+d,c,a,b
+1,'def','def',1.1
+2,'mno','ghi',2.2
+3,null,'jkl',3.3
+4,'def','mno',4.4
+d,c,a,b
+1,'def','def',1.1
+2,'mno','ghi',2.2
+3,null,'jkl',3.3
+4,'def','mno',4.4
+d,c,a,b
+1,'def','def',1.1
+2,'mno','ghi',2.2
+3,null,'jkl',3.3
+4,'def','mno',4.4
+d,c,a,b
+1,'def','def',1.1
+2,'mno','ghi',2.2
+3,null,'jkl',3.3
+4,'def','mno',4.4
+d,c,a,b
+1,'def','def',1.1
+2,'mno','ghi',2.2
+3,null,'jkl',3.3
+4,'def','mno',4.4
+d,c,a,b
+1,'def','def',1.1
+2,'mno','ghi',2.2
+3,null,'jkl',3.3
+4,'def','mno',4.4
+d,c,a,b
+1,'def','def',1.1
+2,'mno','ghi',2.2
+3,null,'jkl',3.3
+4,'def','mno',4.4
+d,c,j,a,b
+1,'def',1,'def',1.1
+2,'mno',2,'ghi',2.2
+3,null,3,'jkl',3.3
+4,'def',4,'mno',4.4
+d,c,j,a,b
+1,'def',1,'def',1.1
+2,'mno',2,'ghi',2.2
+3,null,3,'jkl',3.3
+4,'def',4,'mno',4.4
+d,c,j,a,b
+1,'def',1,'def',1.1
+2,'mno',2,'ghi',2.2
+3,null,3,'jkl',3.3
+4,'def',4,'mno',4.4
+d,c,j,a,b
+1,'def',1,'def',1.1
+2,'mno',2,'ghi',2.2
+3,null,3,'jkl',3.3
+4,'def',4,'mno',4.4
+d,c,j,a,b
+1,'def',1,'def',1.1
+2,'mno',2,'ghi',2.2
+3,null,3,'jkl',3.3
+4,'def',4,'mno',4.4
+d,c,j,a,b
+1,'def',1,'def',1.1
+2,'mno',2,'ghi',2.2
+3,null,3,'jkl',3.3
+4,'def',4,'mno',4.4
 
 Chapter 15
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{$n} d,c,j,a,b
-{0} 4,'def',4,'mno',4.4
-{$n} d,c,j,a,b
-{0} 4,'def',4,'mno',4.4
-{$n} d,c,j,a,b
-{0} 4,'def',4,'mno',4.4
-{$n} d,c,j,a,b
-{0} 4,'def',4,'mno',4.4
-{$n} d,c,j,a,b
-{0} 4,'def',4,'mno',4.4
-{$n} d,c,j,a,b
-{0} 4,'def',4,'mno',4.4
+d,c,a,b
+1,'def','def',1.1
+d,c,a,b
+1,'def','def',1.1
+d,c,a,b
+1,'def','def',1.1
+d,c,a,b
+1,'def','def',1.1
+d,c,a,b
+1,'def','def',1.1
+d,c,a,b
+1,'def','def',1.1
+d,c,a,b
+1,'def','def',1.1
+d,c,j,a,b
+4,'def',4,'mno',4.4
+d,c,j,a,b
+4,'def',4,'mno',4.4
+d,c,j,a,b
+4,'def',4,'mno',4.4
+d,c,j,a,b
+4,'def',4,'mno',4.4
+d,c,j,a,b
+4,'def',4,'mno',4.4
+d,c,j,a,b
+4,'def',4,'mno',4.4
 
 Chapter 16
-{$n} j,c,d,b
-{0} 1,'def',1,1.1
-{$n} j,c,d,b
-{0} 1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
 
 Chapter 17
-{$n} a,b,d
-{0} 'def',1.1,1
-{1} 'def',1.1,4
-{2} 'mno',4.4,2
-{$n} a,b,d
-{0} 'def',1.1,1
-{1} 'def',1.1,4
-{2} 'mno',4.4,2
-{$n} a,b,d
-{0} 'def',1.1,1
-{1} 'def',1.1,4
-{2} 'mno',4.4,2
-{$n} a,b,d
-{0} 'def',1.1,1
-{1} 'def',1.1,4
-{2} 'mno',4.4,2
-{$n} a,b,d
-{0} 'def',1.1,1
-{1} 'def',1.1,4
-{2} 'mno',4.4,2
-{$n} a,b,d
-{0} 'def',1.1,1
-{1} 'def',1.1,4
-{2} 'mno',4.4,2
-{$n} a,b,d
-{0} 'def',1.1,1
-{1} 'def',1.1,4
-{2} 'mno',4.4,2
-{$n} a,b,i,d,j
-{0} 'def',1.1,1,1,1
-{1} 'def',1.1,1,4,4
-{2} 'mno',4.4,4,2,2
-{$n} a,b,i,d,j
-{0} 'def',1.1,1,1,1
-{1} 'def',1.1,1,4,4
-{2} 'mno',4.4,4,2,2
-{$n} a,b,i,d,j
-{0} 'def',1.1,1,1,1
-{1} 'def',1.1,1,4,4
-{2} 'mno',4.4,4,2,2
-{$n} a,b,i,d,j
-{0} 'def',1.1,1,1,1
-{1} 'def',1.1,1,4,4
-{2} 'mno',4.4,4,2,2
-{$n} a,b,i,d,j
-{0} 'def',1.1,1,1,1
-{1} 'def',1.1,1,4,4
-{2} 'mno',4.4,4,2,2
-{$n} a,b,i,d,j
-{0} 'def',1.1,1,1,1
-{1} 'def',1.1,1,4,4
-{2} 'mno',4.4,4,2,2
+a,b,d
+'def',1.1,1
+'def',1.1,4
+'mno',4.4,2
+a,b,d
+'def',1.1,1
+'def',1.1,4
+'mno',4.4,2
+a,b,d
+'def',1.1,1
+'def',1.1,4
+'mno',4.4,2
+a,b,d
+'def',1.1,1
+'def',1.1,4
+'mno',4.4,2
+a,b,d
+'def',1.1,1
+'def',1.1,4
+'mno',4.4,2
+a,b,d
+'def',1.1,1
+'def',1.1,4
+'mno',4.4,2
+a,b,d
+'def',1.1,1
+'def',1.1,4
+'mno',4.4,2
+a,b,i,d,j
+'def',1.1,1,1,1
+'def',1.1,1,4,4
+'mno',4.4,4,2,2
+a,b,i,d,j
+'def',1.1,1,1,1
+'def',1.1,1,4,4
+'mno',4.4,4,2,2
+a,b,i,d,j
+'def',1.1,1,1,1
+'def',1.1,1,4,4
+'mno',4.4,4,2,2
+a,b,i,d,j
+'def',1.1,1,1,1
+'def',1.1,1,4,4
+'mno',4.4,4,2,2
+a,b,i,d,j
+'def',1.1,1,1,1
+'def',1.1,1,4,4
+'mno',4.4,4,2,2
+a,b,i,d,j
+'def',1.1,1,1,1
+'def',1.1,1,4,4
+'mno',4.4,4,2,2
 
 Chapter 18
-{$n} c,d,b
-{0} 'def',1,1.1
-{1} 'def',4,1.1
-{2} 'mno',2,4.4
-{$n} c,d,b
-{0} 'def',1,1.1
-{1} 'def',4,1.1
-{2} 'mno',2,4.4
-{$n} c,d,b
-{0} 'def',1,1.1
-{1} 'def',4,1.1
-{2} 'mno',2,4.4
-{$n} c,d,b
-{0} 'def',1,1.1
-{1} 'def',4,1.1
-{2} 'mno',2,4.4
-{$n} c,d,b
-{0} 'def',1,1.1
-{1} 'def',4,1.1
-{2} 'mno',2,4.4
-{$n} c,d,b
-{0} 'def',1,1.1
-{1} 'def',4,1.1
-{2} 'mno',2,4.4
-{$n} c,d,b
-{0} 'def',1,1.1
-{1} 'def',4,1.1
-{2} 'mno',2,4.4
-{$n} c,d,j,b,i
-{0} 'def',1,1,1.1,1
-{1} 'def',4,4,1.1,1
-{2} 'mno',2,2,4.4,4
-{$n} c,d,j,b,i
-{0} 'def',1,1,1.1,1
-{1} 'def',4,4,1.1,1
-{2} 'mno',2,2,4.4,4
-{$n} c,d,j,b,i
-{0} 'def',1,1,1.1,1
-{1} 'def',4,4,1.1,1
-{2} 'mno',2,2,4.4,4
-{$n} c,d,j,b,i
-{0} 'def',1,1,1.1,1
-{1} 'def',4,4,1.1,1
-{2} 'mno',2,2,4.4,4
-{$n} c,d,j,b,i
-{0} 'def',1,1,1.1,1
-{1} 'def',4,4,1.1,1
-{2} 'mno',2,2,4.4,4
-{$n} c,d,j,b,i
-{0} 'def',1,1,1.1,1
-{1} 'def',4,4,1.1,1
-{2} 'mno',2,2,4.4,4
+c,d,b
+'def',1,1.1
+'def',4,1.1
+'mno',2,4.4
+c,d,b
+'def',1,1.1
+'def',4,1.1
+'mno',2,4.4
+c,d,b
+'def',1,1.1
+'def',4,1.1
+'mno',2,4.4
+c,d,b
+'def',1,1.1
+'def',4,1.1
+'mno',2,4.4
+c,d,b
+'def',1,1.1
+'def',4,1.1
+'mno',2,4.4
+c,d,b
+'def',1,1.1
+'def',4,1.1
+'mno',2,4.4
+c,d,b
+'def',1,1.1
+'def',4,1.1
+'mno',2,4.4
+c,d,j,b,i
+'def',1,1,1.1,1
+'def',4,4,1.1,1
+'mno',2,2,4.4,4
+c,d,j,b,i
+'def',1,1,1.1,1
+'def',4,4,1.1,1
+'mno',2,2,4.4,4
+c,d,j,b,i
+'def',1,1,1.1,1
+'def',4,4,1.1,1
+'mno',2,2,4.4,4
+c,d,j,b,i
+'def',1,1,1.1,1
+'def',4,4,1.1,1
+'mno',2,2,4.4,4
+c,d,j,b,i
+'def',1,1,1.1,1
+'def',4,4,1.1,1
+'mno',2,2,4.4,4
+c,d,j,b,i
+'def',1,1,1.1,1
+'def',4,4,1.1,1
+'mno',2,2,4.4,4
 
 Chapter 19
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
-{instance_id,value_no} a,i,b,d
-{0,0} 'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
+a,i,b,d
+'def',1,1.1,1
 
 Chapter 20
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
-{instance_id,value_no} j,c,d,b
-{0,0} 1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
 
 Chapter 21
-{$n} i,a,b,c
-{0} 1,'def',1.1,'def'
-{1} 2,'ghi',2.2,'mno'
-{2} 3,'jkl',3.3,null
-{3} 4,'mno',4.4,'def'
-{$n} i,a,b,c
-{0} 1,'def',1.1,'def'
-{1} 2,'ghi',2.2,'mno'
-{2} 3,'jkl',3.3,null
-{3} 4,'mno',4.4,'def'
-{$n} i,a,b,c
-{0} 1,'def',1.1,'def'
-{1} 2,'ghi',2.2,'mno'
-{2} 3,'jkl',3.3,null
-{3} 4,'mno',4.4,'def'
-{$n} i,a,b,c
-{0} 1,'def',1.1,'def'
-{1} 2,'ghi',2.2,'mno'
-{2} 3,'jkl',3.3,null
-{3} 4,'mno',4.4,'def'
-{$n} i,a,b,c
-{0} 1,'def',1.1,'def'
-{1} 2,'ghi',2.2,'mno'
-{2} 3,'jkl',3.3,null
-{3} 4,'mno',4.4,'def'
-{$n} i,a,b,c
-{0} 1,'def',1.1,'def'
-{1} 2,'ghi',2.2,'mno'
-{2} 3,'jkl',3.3,null
-{3} 4,'mno',4.4,'def'
-{$n} i,a,b,c
-{0} 1,'def',1.1,'def'
-{1} 2,'ghi',2.2,'mno'
-{2} 3,'jkl',3.3,null
-{3} 4,'mno',4.4,'def'
-{$n} i,a,b,c,j
-{0} 1,'def',1.1,'def',1
-{1} 2,'ghi',2.2,'mno',2
-{2} 3,'jkl',3.3,null,3
-{3} 4,'mno',4.4,'def',4
-{$n} i,a,b,c,j
-{0} 1,'def',1.1,'def',1
-{1} 2,'ghi',2.2,'mno',2
-{2} 3,'jkl',3.3,null,3
-{3} 4,'mno',4.4,'def',4
-{$n} i,a,b,c,j
-{0} 1,'def',1.1,'def',1
-{1} 2,'ghi',2.2,'mno',2
-{2} 3,'jkl',3.3,null,3
-{3} 4,'mno',4.4,'def',4
-{$n} i,a,b,c,j
-{0} 1,'def',1.1,'def',1
-{1} 2,'ghi',2.2,'mno',2
-{2} 3,'jkl',3.3,null,3
-{3} 4,'mno',4.4,'def',4
+i,a,b,c
+1,'def',1.1,'def'
+2,'ghi',2.2,'mno'
+3,'jkl',3.3,null
+4,'mno',4.4,'def'
+i,a,b,c
+1,'def',1.1,'def'
+2,'ghi',2.2,'mno'
+3,'jkl',3.3,null
+4,'mno',4.4,'def'
+i,a,b,c
+1,'def',1.1,'def'
+2,'ghi',2.2,'mno'
+3,'jkl',3.3,null
+4,'mno',4.4,'def'
+i,a,b,c
+1,'def',1.1,'def'
+2,'ghi',2.2,'mno'
+3,'jkl',3.3,null
+4,'mno',4.4,'def'
+i,a,b,c
+1,'def',1.1,'def'
+2,'ghi',2.2,'mno'
+3,'jkl',3.3,null
+4,'mno',4.4,'def'
+i,a,b,c
+1,'def',1.1,'def'
+2,'ghi',2.2,'mno'
+3,'jkl',3.3,null
+4,'mno',4.4,'def'
+i,a,b,c
+1,'def',1.1,'def'
+2,'ghi',2.2,'mno'
+3,'jkl',3.3,null
+4,'mno',4.4,'def'
+i,a,b,c,j
+1,'def',1.1,'def',1
+2,'ghi',2.2,'mno',2
+3,'jkl',3.3,null,3
+4,'mno',4.4,'def',4
+i,a,b,c,j
+1,'def',1.1,'def',1
+2,'ghi',2.2,'mno',2
+3,'jkl',3.3,null,3
+4,'mno',4.4,'def',4
+i,a,b,c,j
+1,'def',1.1,'def',1
+2,'ghi',2.2,'mno',2
+3,'jkl',3.3,null,3
+4,'mno',4.4,'def',4
+i,a,b,c,j
+1,'def',1.1,'def',1
+2,'ghi',2.2,'mno',2
+3,'jkl',3.3,null,3
+4,'mno',4.4,'def',4
 
 Chapter 22
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{1} 2,'mno','ghi',2.2
-{2} 3,null,'jkl',3.3
-{3} 4,'def','mno',4.4
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{1} 2,'mno','ghi',2.2
-{2} 3,null,'jkl',3.3
-{3} 4,'def','mno',4.4
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{1} 2,'mno','ghi',2.2
-{2} 3,null,'jkl',3.3
-{3} 4,'def','mno',4.4
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{1} 2,'mno','ghi',2.2
-{2} 3,null,'jkl',3.3
-{3} 4,'def','mno',4.4
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{1} 2,'mno','ghi',2.2
-{2} 3,null,'jkl',3.3
-{3} 4,'def','mno',4.4
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{1} 2,'mno','ghi',2.2
-{2} 3,null,'jkl',3.3
-{3} 4,'def','mno',4.4
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{1} 2,'mno','ghi',2.2
-{2} 3,null,'jkl',3.3
-{3} 4,'def','mno',4.4
-{$n} d,c,j,a,b
-{0} 1,'def',1,'def',1.1
-{1} 2,'mno',2,'ghi',2.2
-{2} 3,null,3,'jkl',3.3
-{3} 4,'def',4,'mno',4.4
-{$n} d,c,j,a,b
-{0} 1,'def',1,'def',1.1
-{1} 2,'mno',2,'ghi',2.2
-{2} 3,null,3,'jkl',3.3
-{3} 4,'def',4,'mno',4.4
-{$n} d,c,j,a,b
-{0} 1,'def',1,'def',1.1
-{1} 2,'mno',2,'ghi',2.2
-{2} 3,null,3,'jkl',3.3
-{3} 4,'def',4,'mno',4.4
-{$n} d,c,j,a,b
-{0} 1,'def',1,'def',1.1
-{1} 2,'mno',2,'ghi',2.2
-{2} 3,null,3,'jkl',3.3
-{3} 4,'def',4,'mno',4.4
-{$n} d,c,j,a,b
-{0} 1,'def',1,'def',1.1
-{1} 2,'mno',2,'ghi',2.2
-{2} 3,null,3,'jkl',3.3
-{3} 4,'def',4,'mno',4.4
-{$n} d,c,j,a,b
-{0} 1,'def',1,'def',1.1
-{1} 2,'mno',2,'ghi',2.2
-{2} 3,null,3,'jkl',3.3
-{3} 4,'def',4,'mno',4.4
+d,c,a,b
+1,'def','def',1.1
+2,'mno','ghi',2.2
+3,null,'jkl',3.3
+4,'def','mno',4.4
+d,c,a,b
+1,'def','def',1.1
+2,'mno','ghi',2.2
+3,null,'jkl',3.3
+4,'def','mno',4.4
+d,c,a,b
+1,'def','def',1.1
+2,'mno','ghi',2.2
+3,null,'jkl',3.3
+4,'def','mno',4.4
+d,c,a,b
+1,'def','def',1.1
+2,'mno','ghi',2.2
+3,null,'jkl',3.3
+4,'def','mno',4.4
+d,c,a,b
+1,'def','def',1.1
+2,'mno','ghi',2.2
+3,null,'jkl',3.3
+4,'def','mno',4.4
+d,c,a,b
+1,'def','def',1.1
+2,'mno','ghi',2.2
+3,null,'jkl',3.3
+4,'def','mno',4.4
+d,c,a,b
+1,'def','def',1.1
+2,'mno','ghi',2.2
+3,null,'jkl',3.3
+4,'def','mno',4.4
+d,c,j,a,b
+1,'def',1,'def',1.1
+2,'mno',2,'ghi',2.2
+3,null,3,'jkl',3.3
+4,'def',4,'mno',4.4
+d,c,j,a,b
+1,'def',1,'def',1.1
+2,'mno',2,'ghi',2.2
+3,null,3,'jkl',3.3
+4,'def',4,'mno',4.4
+d,c,j,a,b
+1,'def',1,'def',1.1
+2,'mno',2,'ghi',2.2
+3,null,3,'jkl',3.3
+4,'def',4,'mno',4.4
+d,c,j,a,b
+1,'def',1,'def',1.1
+2,'mno',2,'ghi',2.2
+3,null,3,'jkl',3.3
+4,'def',4,'mno',4.4
+d,c,j,a,b
+1,'def',1,'def',1.1
+2,'mno',2,'ghi',2.2
+3,null,3,'jkl',3.3
+4,'def',4,'mno',4.4
+d,c,j,a,b
+1,'def',1,'def',1.1
+2,'mno',2,'ghi',2.2
+3,null,3,'jkl',3.3
+4,'def',4,'mno',4.4
 
 Chapter 23
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{$n} d,c,a,b
-{0} 1,'def','def',1.1
-{$n} d,c,j,a,b
-{0} 4,'def',4,'mno',4.4
-{$n} d,c,j,a,b
-{0} 4,'def',4,'mno',4.4
-{$n} d,c,j,a,b
-{0} 4,'def',4,'mno',4.4
-{$n} d,c,j,a,b
-{0} 4,'def',4,'mno',4.4
-{$n} d,c,j,a,b
-{0} 4,'def',4,'mno',4.4
-{$n} d,c,j,a,b
-{0} 4,'def',4,'mno',4.4
+d,c,a,b
+1,'def','def',1.1
+d,c,a,b
+1,'def','def',1.1
+d,c,a,b
+1,'def','def',1.1
+d,c,a,b
+1,'def','def',1.1
+d,c,a,b
+1,'def','def',1.1
+d,c,a,b
+1,'def','def',1.1
+d,c,a,b
+1,'def','def',1.1
+d,c,j,a,b
+4,'def',4,'mno',4.4
+d,c,j,a,b
+4,'def',4,'mno',4.4
+d,c,j,a,b
+4,'def',4,'mno',4.4
+d,c,j,a,b
+4,'def',4,'mno',4.4
+d,c,j,a,b
+4,'def',4,'mno',4.4
+d,c,j,a,b
+4,'def',4,'mno',4.4
 
 Chapter 24
-{$n} j,c,d,b
-{0} 1,'def',1,1.1
-{$n} j,c,d,b
-{0} 1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
+j,c,d,b
+1,'def',1,1.1
 
 Chapter 25
-{$n} a,b,d
-{0} null,0,null
-{1} 'def',1.1,1
-{2} 'def',1.1,4
-{3} 'ghi',2.2,null
-{4} 'jkl',3.3,null
-{5} 'mno',4.4,2
-{$n} a,b,d
-{0} null,0,null
-{1} 'def',1.1,1
-{2} 'def',1.1,4
-{3} 'ghi',2.2,null
-{4} 'jkl',3.3,null
-{5} 'mno',4.4,2
-{$n} a,b,d
-{0} null,0,null
-{1} 'def',1.1,1
-{2} 'def',1.1,4
-{3} 'ghi',2.2,null
-{4} 'jkl',3.3,null
-{5} 'mno',4.4,2
-{$n} a,b,d
-{0} null,0,null
-{1} 'def',1.1,1
-{2} 'def',1.1,4
-{3} 'ghi',2.2,null
-{4} 'jkl',3.3,null
-{5} 'mno',4.4,2
-{$n} a,b,d
-{0} null,0,null
-{1} 'def',1.1,1
-{2} 'def',1.1,4
-{3} 'ghi',2.2,null
-{4} 'jkl',3.3,null
-{5} 'mno',4.4,2
-{$n} a,b,d
-{0} null,0,null
-{1} 'def',1.1,1
-{2} 'def',1.1,4
-{3} 'ghi',2.2,null
-{4} 'jkl',3.3,null
-{5} 'mno',4.4,2
+a,b,d
+null,0,null
+'def',1.1,1
+'def',1.1,4
+'ghi',2.2,null
+'jkl',3.3,null
+'mno',4.4,2
+a,b,d
+null,0,null
+'def',1.1,1
+'def',1.1,4
+'ghi',2.2,null
+'jkl',3.3,null
+'mno',4.4,2
+a,b,d
+null,0,null
+'def',1.1,1
+'def',1.1,4
+'ghi',2.2,null
+'jkl',3.3,null
+'mno',4.4,2
+a,b,d
+null,0,null
+'def',1.1,1
+'def',1.1,4
+'ghi',2.2,null
+'jkl',3.3,null
+'mno',4.4,2
+a,b,d
+null,0,null
+'def',1.1,1
+'def',1.1,4
+'ghi',2.2,null
+'jkl',3.3,null
+'mno',4.4,2
+a,b,d
+null,0,null
+'def',1.1,1
+'def',1.1,4
+'ghi',2.2,null
+'jkl',3.3,null
+'mno',4.4,2
 
 Chapter 26
-{$n} a,b,d
-{0} null,null,3
-{1} 'def',1.1,1
-{2} 'def',1.1,4
-{3} 'mno',4.4,2
-{$n} a,b,d
-{0} null,null,3
-{1} 'def',1.1,1
-{2} 'def',1.1,4
-{3} 'mno',4.4,2
-{$n} a,b,d
-{0} null,null,3
-{1} 'def',1.1,1
-{2} 'def',1.1,4
-{3} 'mno',4.4,2
-{$n} a,b,d
-{0} null,null,3
-{1} 'def',1.1,1
-{2} 'def',1.1,4
-{3} 'mno',4.4,2
-{$n} a,b,d
-{0} null,null,3
-{1} 'def',1.1,1
-{2} 'def',1.1,4
-{3} 'mno',4.4,2
-{$n} a,b,d
-{0} null,null,3
-{1} 'def',1.1,1
-{2} 'def',1.1,4
-{3} 'mno',4.4,2
+a,b,d
+null,null,3
+'def',1.1,1
+'def',1.1,4
+'mno',4.4,2
+a,b,d
+null,null,3
+'def',1.1,1
+'def',1.1,4
+'mno',4.4,2
+a,b,d
+null,null,3
+'def',1.1,1
+'def',1.1,4
+'mno',4.4,2
+a,b,d
+null,null,3
+'def',1.1,1
+'def',1.1,4
+'mno',4.4,2
+a,b,d
+null,null,3
+'def',1.1,1
+'def',1.1,4
+'mno',4.4,2
+a,b,d
+null,null,3
+'def',1.1,1
+'def',1.1,4
+'mno',4.4,2
 
 Chapter 27
-{$n} j,c,d,b
-{0} 1,'def',1,1.1
-{1} 2,'mno',2,null
-{2} 3,null,3,null
-{3} 4,'def',4,null
-{$n} j,c,d,b
-{0} 1,'def',1,1.1
-{1} 2,'mno',2,null
-{2} 3,null,3,null
-{3} 4,'def',4,null
-{$n} j,c,d,b
-{0} 1,'def',1,1.1
-{1} 2,'mno',2,null
-{2} 3,null,3,null
-{3} 4,'def',4,null
-{$n} j,c,d,b
-{0} 1,'def',1,1.1
-{1} 2,'mno',2,null
-{2} 3,null,3,null
-{3} 4,'def',4,null
-{$n} j,c,d,b
-{0} 1,'def',1,1.1
-{1} 2,'mno',2,null
-{2} 3,null,3,null
-{3} 4,'def',4,null
-{$n} j,c,d,b
-{0} 1,'def',1,1.1
-{1} 2,'mno',2,null
-{2} 3,null,3,null
-{3} 4,'def',4,null
+j,c,d,b
+1,'def',1,1.1
+2,'mno',2,null
+3,null,3,null
+4,'def',4,null
+j,c,d,b
+1,'def',1,1.1
+2,'mno',2,null
+3,null,3,null
+4,'def',4,null
+j,c,d,b
+1,'def',1,1.1
+2,'mno',2,null
+3,null,3,null
+4,'def',4,null
+j,c,d,b
+1,'def',1,1.1
+2,'mno',2,null
+3,null,3,null
+4,'def',4,null
+j,c,d,b
+1,'def',1,1.1
+2,'mno',2,null
+3,null,3,null
+4,'def',4,null
+j,c,d,b
+1,'def',1,1.1
+2,'mno',2,null
+3,null,3,null
+4,'def',4,null
 
 Chapter 28
-{$n} j,c,d,b
-{0} 0,null,null,0
-{1} 1,'def',1,1.1
-{2} 2,'ghi',null,2.2
-{3} 3,'jkl',null,3.3
-{4} 4,'mno',null,4.4
-{$n} j,c,d,b
-{0} 0,null,null,0
-{1} 1,'def',1,1.1
-{2} 2,'ghi',null,2.2
-{3} 3,'jkl',null,3.3
-{4} 4,'mno',null,4.4
-{$n} j,c,d,b
-{0} 0,null,null,0
-{1} 1,'def',1,1.1
-{2} 2,'ghi',null,2.2
-{3} 3,'jkl',null,3.3
-{4} 4,'mno',null,4.4
-{$n} j,c,d,b
-{0} 0,null,null,0
-{1} 1,'def',1,1.1
-{2} 2,'ghi',null,2.2
-{3} 3,'jkl',null,3.3
-{4} 4,'mno',null,4.4
-{$n} j,c,d,b
-{0} 0,null,null,0
-{1} 1,'def',1,1.1
-{2} 2,'ghi',null,2.2
-{3} 3,'jkl',null,3.3
-{4} 4,'mno',null,4.4
-{$n} j,c,d,b
-{0} 0,null,null,0
-{1} 1,'def',1,1.1
-{2} 2,'ghi',null,2.2
-{3} 3,'jkl',null,3.3
-{4} 4,'mno',null,4.4
+j,c,d,b
+0,null,null,0
+1,'def',1,1.1
+2,'ghi',null,2.2
+3,'jkl',null,3.3
+4,'mno',null,4.4
+j,c,d,b
+0,null,null,0
+1,'def',1,1.1
+2,'ghi',null,2.2
+3,'jkl',null,3.3
+4,'mno',null,4.4
+j,c,d,b
+0,null,null,0
+1,'def',1,1.1
+2,'ghi',null,2.2
+3,'jkl',null,3.3
+4,'mno',null,4.4
+j,c,d,b
+0,null,null,0
+1,'def',1,1.1
+2,'ghi',null,2.2
+3,'jkl',null,3.3
+4,'mno',null,4.4
+j,c,d,b
+0,null,null,0
+1,'def',1,1.1
+2,'ghi',null,2.2
+3,'jkl',null,3.3
+4,'mno',null,4.4
+j,c,d,b
+0,null,null,0
+1,'def',1,1.1
+2,'ghi',null,2.2
+3,'jkl',null,3.3
+4,'mno',null,4.4
 
 Chapter 29
-{$n} a,i,b,j
-{0} null,0,0,null
-{1} null,3,null,3
-{2} 'def',1,1.1,1
-{3} 'def',4,null,4
-{4} 'ghi',2,2.2,null
-{5} 'jkl',3,3.3,null
-{6} 'mno',2,null,2
-{7} 'mno',4,4.4,null
-{$n} a,i,b,j
-{0} null,0,0,null
-{1} null,3,null,3
-{2} 'def',1,1.1,1
-{3} 'def',4,null,4
-{4} 'ghi',2,2.2,null
-{5} 'jkl',3,3.3,null
-{6} 'mno',2,null,2
-{7} 'mno',4,4.4,null
+a,i,b,j
+null,0,0,null
+null,3,null,3
+'def',1,1.1,1
+'def',4,null,4
+'ghi',2,2.2,null
+'jkl',3,3.3,null
+'mno',2,null,2
+'mno',4,4.4,null
+a,i,b,j
+null,0,0,null
+null,3,null,3
+'def',1,1.1,1
+'def',4,null,4
+'ghi',2,2.2,null
+'jkl',3,3.3,null
+'mno',2,null,2
+'mno',4,4.4,null
 
 Chapter 30
-{$n} uv,w,x,y_,z
-{0} 0,null,0,null,null
-{1} 1,'def',1.1,'def',1
-{2} 2,'ghi',2.2,'mno',2
-{3} 3,'jkl',3.3,null,3
-{4} 4,'mno',4.4,'def',4
-{$n} i,a,b,c,d
-{0} 0,null,0,null,null
-{1} 1,'def',1.1,'def',1
-{2} 2,'ghi',2.2,'mno',2
-{3} 3,'jkl',3.3,null,3
-{4} 4,'mno',4.4,'def',4
-{$n} i,a,b,c,d
-{0} 0,null,0,null,null
-{1} 1,'def',1.1,'def',1
-{2} 2,'ghi',2.2,'mno',2
-{3} 3,'jkl',3.3,null,3
-{4} 4,'mno',4.4,'def',4
+uv,w,x,y_,z
+0,null,0,null,null
+1,'def',1.1,'def',1
+2,'ghi',2.2,'mno',2
+3,'jkl',3.3,null,3
+4,'mno',4.4,'def',4
+i,a,b,c,d
+0,null,0,null,null
+1,'def',1.1,'def',1
+2,'ghi',2.2,'mno',2
+3,'jkl',3.3,null,3
+4,'mno',4.4,'def',4
+i,a,b,c,d
+0,null,0,null,null
+1,'def',1.1,'def',1
+2,'ghi',2.2,'mno',2
+3,'jkl',3.3,null,3
+4,'mno',4.4,'def',4

--- a/test.sh
+++ b/test.sh
@@ -6,6 +6,30 @@ MYDIR=`pwd`
 OUTFILE=$MYDIR/test.out
 EXPFILE=$MYDIR/test.expected
 
+# Use csv:l format instead of the default dcsv, to suppress printing dimensions
+# because the instance_id dimension will vary based on how many database instances are running.
+FMT='-ocsv:l'
+
+# Use this to log output of queries that produce output in a deterministic order.
+log_query () {
+    iquery "$FMT" -aq "$1" >> $OUTFILE 2>&1
+}
+
+# Use this to log output of queries that don't sort their output.
+# The output is sorted by the shell before writing to the log file.
+log_unsorted_query () {
+    ( iquery "$FMT" -aq "$1" 2>>$OUTFILE ) | print_header_then sort >> $OUTFILE
+}
+
+# Helper function for log_unsorted_query.
+# Given an input stream, prints the first line of the stream,
+# then applies the given command (e.g. sort, grep) to the remainder of the stream.
+print_header_then () {
+    IFS= read -r header
+    printf '%s\n' "$header"
+    "$@"
+}
+
 iquery -anq "remove(left)"  > /dev/null 2>&1
 iquery -anq "remove(right)" > /dev/null 2>&1
 iquery -anq "store(apply(build(<a:string>[i=0:5,2,0], '[(null),(def),(ghi),(jkl),(mno)]', true), b, double(i)*1.1), left)" > /dev/null 2>&1
@@ -13,399 +37,398 @@ iquery -anq "store(apply(build(<c:string>[j=1:5,3,0], '[(def),(mno),(null),(def)
 
 rm $OUTFILE > /dev/null 2>&1
 
-echo " " >> $OUTFILE 2>&1
+echo >> $OUTFILE 2>&1
 echo "Chapter 1" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0                                                                                           ), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'hash_replicate_right'                                                         ), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'hash_replicate_left'                                                          ), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_left_first'                                                             ), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_right_first'                                                            ), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_left_first',     hash_join_threshold:0                                ), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_right_first',    hash_join_threshold:0                                ), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'hash_replicate_right', keep_dimensions:1                                    ), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'hash_replicate_left',  keep_dimensions:1                                    ), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_left_first',     keep_dimensions:1                                    ), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_right_first',    keep_dimensions:1                                    ), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_left_first',     keep_dimensions:1,    hash_join_threshold:0        ), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_right_first',    keep_dimensions:1,    hash_join_threshold:0        ), a,b,d)" >> $OUTFILE 2>&1
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0                                                                                       ), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'hash_replicate_right'                                                     ), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'hash_replicate_left'                                                      ), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_left_first'                                                         ), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_right_first'                                                        ), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_left_first',     hash_join_threshold:0                              ), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_right_first',    hash_join_threshold:0                              ), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'hash_replicate_right', keep_dimensions:1                                  ), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'hash_replicate_left',  keep_dimensions:1                                  ), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_left_first',     keep_dimensions:1                                  ), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_right_first',    keep_dimensions:1                                  ), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_left_first',     keep_dimensions:1,    hash_join_threshold:0        ), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_right_first',    keep_dimensions:1,    hash_join_threshold:0        ), a,b,d)"
 
-
-echo " " >> $OUTFILE 2>&1
+echo >> $OUTFILE 2>&1
 echo "Chapter 2" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0                                                                                           ), c,d,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'hash_replicate_right'                                                         ), c,d,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'hash_replicate_left'                                                          ), c,d,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_left_first'                                                             ), c,d,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_right_first'                                                            ), c,d,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_left_first',     hash_join_threshold:0                                ), c,d,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_right_first',    hash_join_threshold:0                                ), c,d,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'hash_replicate_right', keep_dimensions:1                                    ), c,d,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'hash_replicate_left',  keep_dimensions:1                                    ), c,d,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_left_first',     keep_dimensions:1                                    ), c,d,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_right_first',    keep_dimensions:1                                    ), c,d,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_left_first',     keep_dimensions:1,    hash_join_threshold:0        ), c,d,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_right_first',    keep_dimensions:1,    hash_join_threshold:0        ), c,d,b)" >> $OUTFILE 2>&1
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0                                                                                       ), c,d,b)"
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'hash_replicate_right'                                                     ), c,d,b)"
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'hash_replicate_left'                                                      ), c,d,b)"
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_left_first'                                                         ), c,d,b)"
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_right_first'                                                        ), c,d,b)"
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_left_first',     hash_join_threshold:0                              ), c,d,b)"
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_right_first',    hash_join_threshold:0                              ), c,d,b)"
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'hash_replicate_right', keep_dimensions:1                                  ), c,d,b)"
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'hash_replicate_left',  keep_dimensions:1                                  ), c,d,b)"
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_left_first',     keep_dimensions:1                                  ), c,d,b)"
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_right_first',    keep_dimensions:1                                  ), c,d,b)"
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_left_first',     keep_dimensions:1,    hash_join_threshold:0        ), c,d,b)"
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_right_first',    keep_dimensions:1,    hash_join_threshold:0        ), c,d,b)"
 
-echo " " >> $OUTFILE 2>&1
+echo >> $OUTFILE 2>&1
 echo "Chapter 3" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1)                                                                                                  )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'hash_replicate_right'                                                                )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'hash_replicate_left'                                                                 )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_left_first'                                                                    )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_right_first'                                                                   )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_left_first',     hash_join_threshold:0                                       )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_right_first',    hash_join_threshold:0                                       )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'hash_replicate_right', keep_dimensions:TRUE                                           )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'hash_replicate_left',  keep_dimensions:TRUE                                           )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_left_first',     keep_dimensions:TRUE                                           )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_right_first',    keep_dimensions:TRUE                                           )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_left_first',     keep_dimensions:TRUE,   hash_join_threshold:0                )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_right_first',    keep_dimensions:TRUE,   hash_join_threshold:0                )" >> $OUTFILE 2>&1
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1)                                                                                   )"
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'hash_replicate_right'                                                 )"
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'hash_replicate_left'                                                  )"
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_left_first'                                                     )"
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_right_first'                                                    )"
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_left_first',     hash_join_threshold:0                          )"
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_right_first',    hash_join_threshold:0                          )"
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'hash_replicate_right', keep_dimensions:TRUE                           )"
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'hash_replicate_left',  keep_dimensions:TRUE                           )"
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_left_first',     keep_dimensions:TRUE                           )"
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_right_first',    keep_dimensions:TRUE                           )"
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_left_first',     keep_dimensions:TRUE,   hash_join_threshold:0  )"
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_right_first',    keep_dimensions:TRUE,   hash_join_threshold:0  )"
 
-echo " " >> $OUTFILE 2>&1
+echo >> $OUTFILE 2>&1
 echo "Chapter 4" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0)                                                                                                  )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'hash_replicate_right', keep_dimensions:0                                           )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'hash_replicate_left',  keep_dimensions:0                                           )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_left_first',     keep_dimensions:0                                           )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_right_first',    keep_dimensions:0                                           )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_left_first',     keep_dimensions:0,    hash_join_threshold:0               )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_right_first',    keep_dimensions:0,    hash_join_threshold:0               )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'hash_replicate_right', keep_dimensions:true                                        )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'hash_replicate_left',  keep_dimensions:true                                        )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_left_first',     keep_dimensions:true                                        )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_right_first',    keep_dimensions:true                                        )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_left_first',     keep_dimensions:true, hash_join_threshold:0               )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_right_first',    keep_dimensions:true, hash_join_threshold:0               )" >> $OUTFILE 2>&1
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0)                                                                                   )"
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'hash_replicate_right', keep_dimensions:0                              )"
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'hash_replicate_left',  keep_dimensions:0                              )"
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_left_first',     keep_dimensions:0                              )"
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_right_first',    keep_dimensions:0                              )"
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_left_first',     keep_dimensions:0,    hash_join_threshold:0    )"
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_right_first',    keep_dimensions:0,    hash_join_threshold:0    )"
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'hash_replicate_right', keep_dimensions:true                           )"
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'hash_replicate_left',  keep_dimensions:true                           )"
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_left_first',     keep_dimensions:true                           )"
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_right_first',    keep_dimensions:true                           )"
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_left_first',     keep_dimensions:true, hash_join_threshold:0    )"
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_right_first',    keep_dimensions:true, hash_join_threshold:0    )"
 
-echo " " >> $OUTFILE 2>&1
+echo >> $OUTFILE 2>&1
 echo "Chapter 5" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:-1, right_ids:1                                                                                        ), i,a,b,c)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'hash_replicate_left', keep_dimensions:FALSE                                  ), i,a,b,c)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'hash_replicate_right',keep_dimensions:FALSE                                  ), i,a,b,c)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'merge_left_first',    keep_dimensions:FALSE                                  ), i,a,b,c)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'merge_right_first',   keep_dimensions:FALSE                                  ), i,a,b,c)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'merge_left_first',    keep_dimensions:FALSE,    hash_join_threshold:0      ), i,a,b,c)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'merge_right_first',   keep_dimensions:FALSE,    hash_join_threshold:0      ), i,a,b,c)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'hash_replicate_left', keep_dimensions:TRUE                               ), i,a,b,c)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'hash_replicate_right',keep_dimensions:TRUE                               ), i,a,b,c)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'merge_left_first',    keep_dimensions:TRUE, hash_join_threshold:0      ), i,a,b,c)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'merge_right_first',   keep_dimensions:TRUE, hash_join_threshold:0      ), i,a,b,c)" >> $OUTFILE 2>&1
+log_query "sort(equi_join(left, right, left_ids:-1, right_ids:1                                                                                    ), i,a,b,c)"
+log_query "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'hash_replicate_left', keep_dimensions:FALSE                            ), i,a,b,c)"
+log_query "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'hash_replicate_right',keep_dimensions:FALSE                            ), i,a,b,c)"
+log_query "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'merge_left_first',    keep_dimensions:FALSE                            ), i,a,b,c)"
+log_query "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'merge_right_first',   keep_dimensions:FALSE                            ), i,a,b,c)"
+log_query "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'merge_left_first',    keep_dimensions:FALSE,    hash_join_threshold:0  ), i,a,b,c)"
+log_query "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'merge_right_first',   keep_dimensions:FALSE,    hash_join_threshold:0  ), i,a,b,c)"
+log_query "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'hash_replicate_left', keep_dimensions:TRUE                             ), i,a,b,c)"
+log_query "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'hash_replicate_right',keep_dimensions:TRUE                             ), i,a,b,c)"
+log_query "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'merge_left_first',    keep_dimensions:TRUE, hash_join_threshold:0      ), i,a,b,c)"
+log_query "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'merge_right_first',   keep_dimensions:TRUE, hash_join_threshold:0      ), i,a,b,c)"
 
-echo " " >> $OUTFILE 2>&1
+echo >> $OUTFILE 2>&1
 echo "Chapter 6" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1                                                                                        ), d,c,a,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'hash_replicate_left', keep_dimensions:FALSE                              ), d,c,a,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'hash_replicate_right',keep_dimensions:false                              ), d,c,a,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_left_first',    keep_dimensions:false                              ), d,c,a,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_right_first',   keep_dimensions:false                              ), d,c,a,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_left_first',    keep_dimensions:false, hash_join_threshold:0     ), d,c,a,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_right_first',   keep_dimensions:false, hash_join_threshold:0     ), d,c,a,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'hash_replicate_left', keep_dimensions:true                               ), d,c,a,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'hash_replicate_right',keep_dimensions:TRUE                               ), d,c,a,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_left_first',    keep_dimensions:TRUE                               ), d,c,a,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_right_first',   keep_dimensions:TRUE                               ), d,c,a,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_left_first',    keep_dimensions:TRUE,  hash_join_threshold:0     ), d,c,a,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_right_first',   keep_dimensions:TRUE,  hash_join_threshold:0     ), d,c,a,b)" >> $OUTFILE 2>&1
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1                                                                                    ), d,c,a,b)"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'hash_replicate_left', keep_dimensions:FALSE                            ), d,c,a,b)"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'hash_replicate_right',keep_dimensions:false                            ), d,c,a,b)"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_left_first',    keep_dimensions:false                            ), d,c,a,b)"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_right_first',   keep_dimensions:false                            ), d,c,a,b)"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_left_first',    keep_dimensions:false, hash_join_threshold:0     ), d,c,a,b)"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_right_first',   keep_dimensions:false, hash_join_threshold:0     ), d,c,a,b)"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'hash_replicate_left', keep_dimensions:true                             ), d,c,a,b)"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'hash_replicate_right',keep_dimensions:TRUE                             ), d,c,a,b)"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_left_first',    keep_dimensions:TRUE                             ), d,c,a,b)"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_right_first',   keep_dimensions:TRUE                             ), d,c,a,b)"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_left_first',    keep_dimensions:TRUE,  hash_join_threshold:0     ), d,c,a,b)"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_right_first',   keep_dimensions:TRUE,  hash_join_threshold:0     ), d,c,a,b)"
 
-echo " " >> $OUTFILE 2>&1
+echo >> $OUTFILE 2>&1
 echo "Chapter 7" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c'                                                                                         ))" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c', algorithm:'hash_replicate_left'                                                        ))" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c', algorithm:'hash_replicate_right'                                                       ))" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c', algorithm:'merge_left_first'                                                           ))" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c', algorithm:'merge_right_first'                                                          ))" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c', algorithm:'merge_left_first',     hash_join_threshold:0                              ))" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c', algorithm:'merge_right_first',    hash_join_threshold:0                              ))" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a<>c and j>3', algorithm:'hash_replicate_left', keep_dimensions:1                          ))" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a<>c and j>3', algorithm:'hash_replicate_right',keep_dimensions:1                          ))" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a<>c and j>3', algorithm:'merge_left_first',    keep_dimensions:1                          ))" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a<>c and j>3', algorithm:'merge_right_first',   keep_dimensions:1                          ))" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a<>c and j>3', algorithm:'merge_left_first',    hash_join_threshold:0, keep_dimensions:1 ))" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a<>c and j>3', algorithm:'merge_right_first',   hash_join_threshold:0, keep_dimensions:1 ))" >> $OUTFILE 2>&1
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c'                                                                                     ))"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c', algorithm:'hash_replicate_left'                                                    ))"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c', algorithm:'hash_replicate_right'                                                   ))"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c', algorithm:'merge_left_first'                                                       ))"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c', algorithm:'merge_right_first'                                                      ))"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c', algorithm:'merge_left_first',     hash_join_threshold:0                            ))"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c', algorithm:'merge_right_first',    hash_join_threshold:0                            ))"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a<>c and j>3', algorithm:'hash_replicate_left', keep_dimensions:1                        ))"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a<>c and j>3', algorithm:'hash_replicate_right',keep_dimensions:1                        ))"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a<>c and j>3', algorithm:'merge_left_first',    keep_dimensions:1                        ))"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a<>c and j>3', algorithm:'merge_right_first',   keep_dimensions:1                        ))"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a<>c and j>3', algorithm:'merge_left_first',    hash_join_threshold:0, keep_dimensions:1 ))"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a<>c and j>3', algorithm:'merge_right_first',   hash_join_threshold:0, keep_dimensions:1 ))"
 
-echo " " >> $OUTFILE 2>&1
+echo >> $OUTFILE 2>&1
 echo "Chapter 8" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_names:(j,c), right_names:(i,a), algorithm:'merge_left_first', keep_dimensions:0))"  >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_names:(j,c), right_ids:(-1,0), algorithm:'merge_left_first', keep_dimensions:0 ))"  >> $OUTFILE 2>&1
+log_query "sort(equi_join(right, left, left_names:(j,c), right_names:(i,a), algorithm:'merge_left_first', keep_dimensions:0))"
+log_query "sort(equi_join(right, left, left_names:(j,c), right_ids:(-1,0), algorithm:'merge_left_first', keep_dimensions:0 ))"
 
-echo " " >> $OUTFILE 2>&1
+echo >> $OUTFILE 2>&1
 echo "Chapter 9" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0                                                                                   , chunk_size:1        ), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'hash_replicate_right'                                                 , chunk_size:1        ), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'hash_replicate_left'                                                  , chunk_size:1        ), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_left_first'                                                     , chunk_size:1        ), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_right_first'                                                    , chunk_size:1        ), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_left_first',     hash_join_threshold:0                        , chunk_size:1        ), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_right_first',    hash_join_threshold:0                        , chunk_size:1        ), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'hash_replicate_right', keep_dimensions:1                            , chunk_size:1        ), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'hash_replicate_left',  keep_dimensions:1                            , chunk_size:1        ), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_left_first',     keep_dimensions:1                            , chunk_size:1        ), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_right_first',    keep_dimensions:1                            , chunk_size:1        ), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_left_first',     keep_dimensions:1,    hash_join_threshold:0, chunk_size:1        ), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_right_first',    keep_dimensions:1,    hash_join_threshold:0, chunk_size:1        ), a,b,d)" >> $OUTFILE 2>&1
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0                                                                                 , chunk_size:1  ), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'hash_replicate_right'                                               , chunk_size:1  ), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'hash_replicate_left'                                                , chunk_size:1  ), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_left_first'                                                   , chunk_size:1  ), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_right_first'                                                  , chunk_size:1  ), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_left_first',     hash_join_threshold:0                        , chunk_size:1  ), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_right_first',    hash_join_threshold:0                        , chunk_size:1  ), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'hash_replicate_right', keep_dimensions:1                            , chunk_size:1  ), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'hash_replicate_left',  keep_dimensions:1                            , chunk_size:1  ), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_left_first',     keep_dimensions:1                            , chunk_size:1  ), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_right_first',    keep_dimensions:1                            , chunk_size:1  ), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_left_first',     keep_dimensions:1,    hash_join_threshold:0, chunk_size:1    ), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_right_first',    keep_dimensions:1,    hash_join_threshold:0, chunk_size:1    ), a,b,d)"
 
 
-echo " " >> $OUTFILE 2>&1
+echo >> $OUTFILE 2>&1
 echo "Chapter 10" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0                                                                                   , chunk_size:1        ), c,d,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'hash_replicate_right'                                                 , chunk_size:1        ), c,d,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'hash_replicate_left'                                                  , chunk_size:1        ), c,d,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_left_first'                                                     , chunk_size:1        ), c,d,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_right_first'                                                    , chunk_size:1        ), c,d,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_left_first',     hash_join_threshold:0                        , chunk_size:1        ), c,d,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_right_first',    hash_join_threshold:0                        , chunk_size:1        ), c,d,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'hash_replicate_right', keep_dimensions:1                            , chunk_size:1        ), c,d,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'hash_replicate_left',  keep_dimensions:1                            , chunk_size:1        ), c,d,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_left_first',     keep_dimensions:1                            , chunk_size:1        ), c,d,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_right_first',    keep_dimensions:1                            , chunk_size:1        ), c,d,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_left_first',     keep_dimensions:1,    hash_join_threshold:0, chunk_size:1        ), c,d,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_right_first',    keep_dimensions:1,    hash_join_threshold:0, chunk_size:1        ), c,d,b)" >> $OUTFILE 2>&1
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0                                                                               , chunk_size:1  ), c,d,b)"
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'hash_replicate_right'                                             , chunk_size:1  ), c,d,b)"
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'hash_replicate_left'                                              , chunk_size:1  ), c,d,b)"
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_left_first'                                                 , chunk_size:1  ), c,d,b)"
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_right_first'                                                , chunk_size:1  ), c,d,b)"
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_left_first',     hash_join_threshold:0                      , chunk_size:1  ), c,d,b)"
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_right_first',    hash_join_threshold:0                      , chunk_size:1  ), c,d,b)"
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'hash_replicate_right', keep_dimensions:1                          , chunk_size:1  ), c,d,b)"
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'hash_replicate_left',  keep_dimensions:1                          , chunk_size:1  ), c,d,b)"
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_left_first',     keep_dimensions:1                          , chunk_size:1  ), c,d,b)"
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_right_first',    keep_dimensions:1                          , chunk_size:1  ), c,d,b)"
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_left_first',     keep_dimensions:1,    hash_join_threshold:0, chunk_size:1  ), c,d,b)"
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_right_first',    keep_dimensions:1,    hash_join_threshold:0, chunk_size:1  ), c,d,b)"
 
-echo " " >> $OUTFILE 2>&1
+echo >> $OUTFILE 2>&1
 echo "Chapter 11" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1)                                                                                  , chunk_size:1                )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'hash_replicate_right'                                                , chunk_size:1                )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'hash_replicate_left'                                                 , chunk_size:1                )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_left_first'                                                    , chunk_size:1                )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_right_first'                                                   , chunk_size:1                )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_left_first',     hash_join_threshold:0                       , chunk_size:1                )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_right_first',    hash_join_threshold:0                       , chunk_size:1                )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'hash_replicate_right', keep_dimensions:TRUE                           , chunk_size:1                )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'hash_replicate_left',  keep_dimensions:TRUE                           , chunk_size:1                )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_left_first',     keep_dimensions:TRUE                           , chunk_size:1                )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_right_first',    keep_dimensions:TRUE                           , chunk_size:1                )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_left_first',     keep_dimensions:TRUE,   hash_join_threshold:0, chunk_size:1                )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_right_first',    keep_dimensions:TRUE,   hash_join_threshold:0, chunk_size:1                )" >> $OUTFILE 2>&1
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1)                                                                                 , chunk_size:1 )"
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'hash_replicate_right'                                               , chunk_size:1 )"
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'hash_replicate_left'                                                , chunk_size:1 )"
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_left_first'                                                   , chunk_size:1 )"
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_right_first'                                                  , chunk_size:1 )"
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_left_first',     hash_join_threshold:0                        , chunk_size:1 )"
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_right_first',    hash_join_threshold:0                        , chunk_size:1 )"
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'hash_replicate_right', keep_dimensions:TRUE                         , chunk_size:1 )"
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'hash_replicate_left',  keep_dimensions:TRUE                         , chunk_size:1 )"
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_left_first',     keep_dimensions:TRUE                         , chunk_size:1 )"
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_right_first',    keep_dimensions:TRUE                         , chunk_size:1 )"
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_left_first',     keep_dimensions:TRUE,   hash_join_threshold:0, chunk_size:1 )"
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_right_first',    keep_dimensions:TRUE,   hash_join_threshold:0, chunk_size:1 )"
 
-echo " " >> $OUTFILE 2>&1
+echo >> $OUTFILE 2>&1
 echo "Chapter 12" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0)                                                                                   , chunk_size:1               )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'hash_replicate_right', keep_dimensions:0                            , chunk_size:1               )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'hash_replicate_left',  keep_dimensions:0                            , chunk_size:1               )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_left_first',     keep_dimensions:0                            , chunk_size:1               )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_right_first',    keep_dimensions:0                            , chunk_size:1               )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_left_first',     keep_dimensions:0,    hash_join_threshold:0, chunk_size:1               )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_right_first',    keep_dimensions:0,    hash_join_threshold:0, chunk_size:1               )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'hash_replicate_right', keep_dimensions:true                         , chunk_size:1               )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'hash_replicate_left',  keep_dimensions:true                         , chunk_size:1               )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_left_first',     keep_dimensions:true                         , chunk_size:1               )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_right_first',    keep_dimensions:true                         , chunk_size:1               )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_left_first',     keep_dimensions:true, hash_join_threshold:0, chunk_size:1               )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_right_first',    keep_dimensions:true, hash_join_threshold:0, chunk_size:1               )" >> $OUTFILE 2>&1
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0)                                                                                 , chunk_size:1 )"
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'hash_replicate_right', keep_dimensions:0                            , chunk_size:1 )"
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'hash_replicate_left',  keep_dimensions:0                            , chunk_size:1 )"
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_left_first',     keep_dimensions:0                            , chunk_size:1 )"
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_right_first',    keep_dimensions:0                            , chunk_size:1 )"
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_left_first',     keep_dimensions:0,    hash_join_threshold:0  , chunk_size:1 )"
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_right_first',    keep_dimensions:0,    hash_join_threshold:0  , chunk_size:1 )"
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'hash_replicate_right', keep_dimensions:true                         , chunk_size:1 )"
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'hash_replicate_left',  keep_dimensions:true                         , chunk_size:1 )"
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_left_first',     keep_dimensions:true                         , chunk_size:1 )"
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_right_first',    keep_dimensions:true                         , chunk_size:1 )"
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_left_first',     keep_dimensions:true, hash_join_threshold:0  , chunk_size:1 )"
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_right_first',    keep_dimensions:true, hash_join_threshold:0  , chunk_size:1 )"
 
-echo " " >> $OUTFILE 2>&1
+echo >> $OUTFILE 2>&1
 echo "Chapter 13" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:-1, right_ids:1                                                                                   , chunk_size:1     ), i,a,b,c)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'hash_replicate_left', keep_dimensions:FALSE                             , chunk_size:1     ), i,a,b,c)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'hash_replicate_right',keep_dimensions:FALSE                             , chunk_size:1     ), i,a,b,c)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'merge_left_first',    keep_dimensions:FALSE                             , chunk_size:1     ), i,a,b,c)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'merge_right_first',   keep_dimensions:FALSE                             , chunk_size:1     ), i,a,b,c)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'merge_left_first',    keep_dimensions:FALSE,    hash_join_threshold:0 , chunk_size:1     ), i,a,b,c)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'merge_right_first',   keep_dimensions:FALSE,    hash_join_threshold:0 , chunk_size:1     ), i,a,b,c)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'hash_replicate_left', keep_dimensions:TRUE                          , chunk_size:1     ), i,a,b,c)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'hash_replicate_right',keep_dimensions:TRUE                          , chunk_size:1     ), i,a,b,c)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'merge_left_first',    keep_dimensions:TRUE, hash_join_threshold:0 , chunk_size:1     ), i,a,b,c)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'merge_right_first',   keep_dimensions:TRUE, hash_join_threshold:0 , chunk_size:1     ), i,a,b,c)" >> $OUTFILE 2>&1
+log_query "sort(equi_join(left, right, left_ids:-1, right_ids:1                                                                               , chunk_size:1 ), i,a,b,c)"
+log_query "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'hash_replicate_left', keep_dimensions:FALSE                       , chunk_size:1 ), i,a,b,c)"
+log_query "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'hash_replicate_right',keep_dimensions:FALSE                       , chunk_size:1 ), i,a,b,c)"
+log_query "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'merge_left_first',    keep_dimensions:FALSE                       , chunk_size:1 ), i,a,b,c)"
+log_query "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'merge_right_first',   keep_dimensions:FALSE                       , chunk_size:1 ), i,a,b,c)"
+log_query "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'merge_left_first',    keep_dimensions:FALSE, hash_join_threshold:0, chunk_size:1 ), i,a,b,c)"
+log_query "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'merge_right_first',   keep_dimensions:FALSE, hash_join_threshold:0, chunk_size:1 ), i,a,b,c)"
+log_query "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'hash_replicate_left', keep_dimensions:TRUE                        , chunk_size:1 ), i,a,b,c)"
+log_query "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'hash_replicate_right',keep_dimensions:TRUE                        , chunk_size:1 ), i,a,b,c)"
+log_query "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'merge_left_first',    keep_dimensions:TRUE,  hash_join_threshold:0, chunk_size:1 ), i,a,b,c)"
+log_query "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'merge_right_first',   keep_dimensions:TRUE,  hash_join_threshold:0, chunk_size:1 ), i,a,b,c)"
 
-echo " " >> $OUTFILE 2>&1
+echo >> $OUTFILE 2>&1
 echo "Chapter 14" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1                                                                                   , chunk_size:1     ), d,c,a,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'hash_replicate_left', keep_dimensions:FALSE                         , chunk_size:1     ), d,c,a,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'hash_replicate_right',keep_dimensions:false                         , chunk_size:1     ), d,c,a,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_left_first',    keep_dimensions:false                         , chunk_size:1     ), d,c,a,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_right_first',   keep_dimensions:false                         , chunk_size:1     ), d,c,a,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_left_first',    keep_dimensions:false, hash_join_threshold:0, chunk_size:1     ), d,c,a,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_right_first',   keep_dimensions:false, hash_join_threshold:0, chunk_size:1     ), d,c,a,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'hash_replicate_left', keep_dimensions:true                          , chunk_size:1     ), d,c,a,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'hash_replicate_right',keep_dimensions:TRUE                          , chunk_size:1     ), d,c,a,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_left_first',    keep_dimensions:TRUE                          , chunk_size:1     ), d,c,a,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_right_first',   keep_dimensions:TRUE                          , chunk_size:1     ), d,c,a,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_left_first',    keep_dimensions:TRUE,  hash_join_threshold:0, chunk_size:1     ), d,c,a,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_right_first',   keep_dimensions:TRUE,  hash_join_threshold:0, chunk_size:1     ), d,c,a,b)" >> $OUTFILE 2>&1
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1                                                                               , chunk_size:1 ), d,c,a,b)"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'hash_replicate_left', keep_dimensions:FALSE                       , chunk_size:1 ), d,c,a,b)"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'hash_replicate_right',keep_dimensions:false                       , chunk_size:1 ), d,c,a,b)"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_left_first',    keep_dimensions:false                       , chunk_size:1 ), d,c,a,b)"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_right_first',   keep_dimensions:false                       , chunk_size:1 ), d,c,a,b)"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_left_first',    keep_dimensions:false, hash_join_threshold:0, chunk_size:1 ), d,c,a,b)"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_right_first',   keep_dimensions:false, hash_join_threshold:0, chunk_size:1 ), d,c,a,b)"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'hash_replicate_left', keep_dimensions:true                        , chunk_size:1 ), d,c,a,b)"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'hash_replicate_right',keep_dimensions:TRUE                        , chunk_size:1 ), d,c,a,b)"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_left_first',    keep_dimensions:TRUE                        , chunk_size:1 ), d,c,a,b)"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_right_first',   keep_dimensions:TRUE                        , chunk_size:1 ), d,c,a,b)"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_left_first',    keep_dimensions:TRUE,  hash_join_threshold:0, chunk_size:1 ), d,c,a,b)"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_right_first',   keep_dimensions:TRUE,  hash_join_threshold:0, chunk_size:1 ), d,c,a,b)"
 
-echo " " >> $OUTFILE 2>&1
+echo >> $OUTFILE 2>&1
 echo "Chapter 15" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c'                                                                     , chunk_size:1                    ))" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c', algorithm:'hash_replicate_left'                                    , chunk_size:1                    ))" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c', algorithm:'hash_replicate_right'                                   , chunk_size:1                    ))" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c', algorithm:'merge_left_first'                                       , chunk_size:1                    ))" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c', algorithm:'merge_right_first'                                      , chunk_size:1                    ))" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c', algorithm:'merge_left_first',     hash_join_threshold:0          , chunk_size:1                    ))" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c', algorithm:'merge_right_first',    hash_join_threshold:0          , chunk_size:1                    ))" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a<>c and j>3', algorithm:'hash_replicate_left', keep_dimensions:1      , chunk_size:1                    ))" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a<>c and j>3', algorithm:'hash_replicate_right',keep_dimensions:1      , chunk_size:1                    ))" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a<>c and j>3', algorithm:'merge_left_first',    keep_dimensions:1      , chunk_size:1                    ))" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a<>c and j>3', algorithm:'merge_right_first',   keep_dimensions:1      , chunk_size:1                    ))" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a<>c and j>3', algorithm:'merge_left_first',    hash_join_threshold:0, keep_dimensions:1, chunk_size:1 ))" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a<>c and j>3', algorithm:'merge_right_first',   hash_join_threshold:0, keep_dimensions:1, chunk_size:1 ))" >> $OUTFILE 2>&1
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c'                                                                   , chunk_size:1                  ))"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c', algorithm:'hash_replicate_left'                                  , chunk_size:1                  ))"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c', algorithm:'hash_replicate_right'                                 , chunk_size:1                  ))"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c', algorithm:'merge_left_first'                                     , chunk_size:1                  ))"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c', algorithm:'merge_right_first'                                    , chunk_size:1                  ))"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c', algorithm:'merge_left_first',     hash_join_threshold:0          , chunk_size:1                  ))"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c', algorithm:'merge_right_first',    hash_join_threshold:0          , chunk_size:1                  ))"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a<>c and j>3', algorithm:'hash_replicate_left', keep_dimensions:1      , chunk_size:1                  ))"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a<>c and j>3', algorithm:'hash_replicate_right',keep_dimensions:1      , chunk_size:1                  ))"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a<>c and j>3', algorithm:'merge_left_first',    keep_dimensions:1      , chunk_size:1                  ))"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a<>c and j>3', algorithm:'merge_right_first',   keep_dimensions:1      , chunk_size:1                  ))"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a<>c and j>3', algorithm:'merge_left_first',    hash_join_threshold:0, keep_dimensions:1, chunk_size:1 ))"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a<>c and j>3', algorithm:'merge_right_first',   hash_join_threshold:0, keep_dimensions:1, chunk_size:1 ))"
 
-echo " " >> $OUTFILE 2>&1
+echo >> $OUTFILE 2>&1
 echo "Chapter 16" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_names:(j, c), right_names:(i,a), algorithm:'merge_left_first', keep_dimensions:0, chunk_size:1))"  >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_names:(j,c) , right_ids:(-1,0), algorithm:'merge_left_first', keep_dimensions:0,  chunk_size:1 ))"  >> $OUTFILE 2>&1
+log_query "sort(equi_join(right, left, left_names:(j, c), right_names:(i,a), algorithm:'merge_left_first', keep_dimensions:0, chunk_size:1))"
+log_query "sort(equi_join(right, left, left_names:(j,c) , right_ids:(-1,0), algorithm:'merge_left_first', keep_dimensions:0,  chunk_size:1 ))"
 
-echo " " >> $OUTFILE 2>&1
+echo >> $OUTFILE 2>&1
 echo "Chapter 17" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0                                                                                   , chunk_size:2        ), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'hash_replicate_right'                                                 , chunk_size:2        ), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'hash_replicate_left'                                                  , chunk_size:2        ), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_left_first'                                                     , chunk_size:2        ), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_right_first'                                                    , chunk_size:2        ), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_left_first',     hash_join_threshold:0                        , chunk_size:2        ), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_right_first',    hash_join_threshold:0                        , chunk_size:2        ), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'hash_replicate_right', keep_dimensions:1                            , chunk_size:2        ), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'hash_replicate_left',  keep_dimensions:1                            , chunk_size:2        ), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_left_first',     keep_dimensions:1                            , chunk_size:2        ), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_right_first',    keep_dimensions:1                            , chunk_size:2        ), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_left_first',     keep_dimensions:1,    hash_join_threshold:0, chunk_size:2        ), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_right_first',    keep_dimensions:1,    hash_join_threshold:0, chunk_size:2        ), a,b,d)" >> $OUTFILE 2>&1
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0                                                                               , chunk_size:2  ), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'hash_replicate_right'                                             , chunk_size:2  ), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'hash_replicate_left'                                              , chunk_size:2  ), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_left_first'                                                 , chunk_size:2  ), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_right_first'                                                , chunk_size:2  ), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_left_first',     hash_join_threshold:0                      , chunk_size:2  ), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_right_first',    hash_join_threshold:0                      , chunk_size:2  ), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'hash_replicate_right', keep_dimensions:1                          , chunk_size:2  ), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'hash_replicate_left',  keep_dimensions:1                          , chunk_size:2  ), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_left_first',     keep_dimensions:1                          , chunk_size:2  ), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_right_first',    keep_dimensions:1                          , chunk_size:2  ), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_left_first',     keep_dimensions:1,    hash_join_threshold:0, chunk_size:2  ), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, algorithm:'merge_right_first',    keep_dimensions:1,    hash_join_threshold:0, chunk_size:2  ), a,b,d)"
 
 
-echo " " >> $OUTFILE 2>&1
+echo >> $OUTFILE 2>&1
 echo "Chapter 18" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0                                                                                   , chunk_size:2        ), c,d,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'hash_replicate_right'                                                 , chunk_size:2        ), c,d,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'hash_replicate_left'                                                  , chunk_size:2        ), c,d,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_left_first'                                                     , chunk_size:2        ), c,d,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_right_first'                                                    , chunk_size:2        ), c,d,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_left_first',     hash_join_threshold:0                        , chunk_size:2        ), c,d,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_right_first',    hash_join_threshold:0                        , chunk_size:2        ), c,d,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'hash_replicate_right', keep_dimensions:1                            , chunk_size:2        ), c,d,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'hash_replicate_left',  keep_dimensions:1                            , chunk_size:2        ), c,d,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_left_first',     keep_dimensions:1                            , chunk_size:2        ), c,d,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_right_first',    keep_dimensions:1                            , chunk_size:2        ), c,d,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_left_first',     keep_dimensions:1,    hash_join_threshold:0, chunk_size:2        ), c,d,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_right_first',    keep_dimensions:1,    hash_join_threshold:0, chunk_size:2        ), c,d,b)" >> $OUTFILE 2>&1
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0                                                                               , chunk_size:2  ), c,d,b)"
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'hash_replicate_right'                                             , chunk_size:2  ), c,d,b)"
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'hash_replicate_left'                                              , chunk_size:2  ), c,d,b)"
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_left_first'                                                 , chunk_size:2  ), c,d,b)"
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_right_first'                                                , chunk_size:2  ), c,d,b)"
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_left_first',     hash_join_threshold:0                      , chunk_size:2  ), c,d,b)"
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_right_first',    hash_join_threshold:0                      , chunk_size:2  ), c,d,b)"
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'hash_replicate_right', keep_dimensions:1                          , chunk_size:2  ), c,d,b)"
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'hash_replicate_left',  keep_dimensions:1                          , chunk_size:2  ), c,d,b)"
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_left_first',     keep_dimensions:1                          , chunk_size:2  ), c,d,b)"
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_right_first',    keep_dimensions:1                          , chunk_size:2  ), c,d,b)"
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_left_first',     keep_dimensions:1,    hash_join_threshold:0, chunk_size:2  ), c,d,b)"
+log_query "sort(equi_join(right, left, left_ids:0, right_ids:0, algorithm:'merge_right_first',    keep_dimensions:1,    hash_join_threshold:0, chunk_size:2  ), c,d,b)"
 
-echo " " >> $OUTFILE 2>&1
+echo >> $OUTFILE 2>&1
 echo "Chapter 19" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1)                                                                                  , chunk_size:2                )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'hash_replicate_right'                                                , chunk_size:2                )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'hash_replicate_left'                                                 , chunk_size:2                )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_left_first'                                                    , chunk_size:2                )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_right_first'                                                   , chunk_size:2                )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_left_first',     hash_join_threshold:0                       , chunk_size:2                )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_right_first',    hash_join_threshold:0                       , chunk_size:2                )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'hash_replicate_right', keep_dimensions:TRUE                           , chunk_size:2                )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'hash_replicate_left',  keep_dimensions:TRUE                           , chunk_size:2                )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_left_first',     keep_dimensions:TRUE                           , chunk_size:2                )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_right_first',    keep_dimensions:TRUE                           , chunk_size:2                )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_left_first',     keep_dimensions:TRUE,   hash_join_threshold:0, chunk_size:2                )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_right_first',    keep_dimensions:TRUE,   hash_join_threshold:0, chunk_size:2                )" >> $OUTFILE 2>&1
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1)                                                                                 , chunk_size:2                )"
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'hash_replicate_right'                                               , chunk_size:2                )"
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'hash_replicate_left'                                                , chunk_size:2                )"
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_left_first'                                                   , chunk_size:2                )"
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_right_first'                                                  , chunk_size:2                )"
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_left_first',     hash_join_threshold:0                        , chunk_size:2                )"
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_right_first',    hash_join_threshold:0                        , chunk_size:2                )"
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'hash_replicate_right', keep_dimensions:TRUE                         , chunk_size:2                )"
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'hash_replicate_left',  keep_dimensions:TRUE                         , chunk_size:2                )"
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_left_first',     keep_dimensions:TRUE                         , chunk_size:2                )"
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_right_first',    keep_dimensions:TRUE                         , chunk_size:2                )"
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_left_first',     keep_dimensions:TRUE,   hash_join_threshold:0, chunk_size:2                )"
+log_unsorted_query "equi_join(left, right, left_ids:(0,-1), right_ids:(0,-1), algorithm:'merge_right_first',    keep_dimensions:TRUE,   hash_join_threshold:0, chunk_size:2                )"
 
-echo " " >> $OUTFILE 2>&1
+echo >> $OUTFILE 2>&1
 echo "Chapter 20" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0)                                                                                   , chunk_size:2               )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'hash_replicate_right', keep_dimensions:0                            , chunk_size:2               )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'hash_replicate_left',  keep_dimensions:0                            , chunk_size:2               )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_left_first',     keep_dimensions:0                            , chunk_size:2               )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_right_first',    keep_dimensions:0                            , chunk_size:2               )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_left_first',     keep_dimensions:0,    hash_join_threshold:0, chunk_size:2               )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_right_first',    keep_dimensions:0,    hash_join_threshold:0, chunk_size:2               )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'hash_replicate_right', keep_dimensions:true                         , chunk_size:2               )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'hash_replicate_left',  keep_dimensions:true                         , chunk_size:2               )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_left_first',     keep_dimensions:true                         , chunk_size:2               )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_right_first',    keep_dimensions:true                         , chunk_size:2               )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_left_first',     keep_dimensions:true, hash_join_threshold:0, chunk_size:2               )" >> $OUTFILE 2>&1
-iquery -aq "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_right_first',    keep_dimensions:true, hash_join_threshold:0, chunk_size:2               )" >> $OUTFILE 2>&1
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0)                                                                               , chunk_size:2               )"
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'hash_replicate_right', keep_dimensions:0                          , chunk_size:2               )"
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'hash_replicate_left',  keep_dimensions:0                          , chunk_size:2               )"
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_left_first',     keep_dimensions:0                          , chunk_size:2               )"
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_right_first',    keep_dimensions:0                          , chunk_size:2               )"
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_left_first',     keep_dimensions:0,    hash_join_threshold:0, chunk_size:2               )"
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_right_first',    keep_dimensions:0,    hash_join_threshold:0, chunk_size:2               )"
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'hash_replicate_right', keep_dimensions:true                       , chunk_size:2               )"
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'hash_replicate_left',  keep_dimensions:true                       , chunk_size:2               )"
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_left_first',     keep_dimensions:true                       , chunk_size:2               )"
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_right_first',    keep_dimensions:true                       , chunk_size:2               )"
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_left_first',     keep_dimensions:true, hash_join_threshold:0, chunk_size:2               )"
+log_unsorted_query "equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), algorithm:'merge_right_first',    keep_dimensions:true, hash_join_threshold:0, chunk_size:2               )"
 
-echo " " >> $OUTFILE 2>&1
+echo >> $OUTFILE 2>&1
 echo "Chapter 21" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:-1, right_ids:1                                                                                   , chunk_size:2     ), i,a,b,c)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'hash_replicate_left', keep_dimensions:FALSE                             , chunk_size:2     ), i,a,b,c)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'hash_replicate_right',keep_dimensions:FALSE                             , chunk_size:2     ), i,a,b,c)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'merge_left_first',    keep_dimensions:FALSE                             , chunk_size:2     ), i,a,b,c)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'merge_right_first',   keep_dimensions:FALSE                             , chunk_size:2     ), i,a,b,c)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'merge_left_first',    keep_dimensions:FALSE,    hash_join_threshold:0 , chunk_size:2     ), i,a,b,c)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'merge_right_first',   keep_dimensions:FALSE,    hash_join_threshold:0 , chunk_size:2     ), i,a,b,c)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'hash_replicate_left', keep_dimensions:TRUE                          , chunk_size:2     ), i,a,b,c)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'hash_replicate_right',keep_dimensions:TRUE                          , chunk_size:2     ), i,a,b,c)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'merge_left_first',    keep_dimensions:TRUE, hash_join_threshold:0 , chunk_size:2     ), i,a,b,c)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'merge_right_first',   keep_dimensions:TRUE, hash_join_threshold:0 , chunk_size:2     ), i,a,b,c)" >> $OUTFILE 2>&1
+log_query "sort(equi_join(left, right, left_ids:-1, right_ids:1                                                                               , chunk_size:2 ), i,a,b,c)"
+log_query "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'hash_replicate_left', keep_dimensions:FALSE                       , chunk_size:2 ), i,a,b,c)"
+log_query "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'hash_replicate_right',keep_dimensions:FALSE                       , chunk_size:2 ), i,a,b,c)"
+log_query "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'merge_left_first',    keep_dimensions:FALSE                       , chunk_size:2 ), i,a,b,c)"
+log_query "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'merge_right_first',   keep_dimensions:FALSE                       , chunk_size:2 ), i,a,b,c)"
+log_query "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'merge_left_first',    keep_dimensions:FALSE, hash_join_threshold:0, chunk_size:2 ), i,a,b,c)"
+log_query "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'merge_right_first',   keep_dimensions:FALSE, hash_join_threshold:0, chunk_size:2 ), i,a,b,c)"
+log_query "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'hash_replicate_left', keep_dimensions:TRUE                        , chunk_size:2 ), i,a,b,c)"
+log_query "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'hash_replicate_right',keep_dimensions:TRUE                        , chunk_size:2 ), i,a,b,c)"
+log_query "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'merge_left_first',    keep_dimensions:TRUE, hash_join_threshold:0 , chunk_size:2 ), i,a,b,c)"
+log_query "sort(equi_join(left, right, left_ids:-1, right_ids:1, algorithm:'merge_right_first',   keep_dimensions:TRUE, hash_join_threshold:0 , chunk_size:2 ), i,a,b,c)"
 
-echo " " >> $OUTFILE 2>&1
+echo >> $OUTFILE 2>&1
 echo "Chapter 22" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1                                                                                   , chunk_size:2     ), d,c,a,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'hash_replicate_left', keep_dimensions:FALSE                         , chunk_size:2     ), d,c,a,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'hash_replicate_right',keep_dimensions:false                         , chunk_size:2     ), d,c,a,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_left_first',    keep_dimensions:false                         , chunk_size:2     ), d,c,a,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_right_first',   keep_dimensions:false                         , chunk_size:2     ), d,c,a,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_left_first',    keep_dimensions:false, hash_join_threshold:0, chunk_size:2     ), d,c,a,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_right_first',   keep_dimensions:false, hash_join_threshold:0, chunk_size:2     ), d,c,a,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'hash_replicate_left', keep_dimensions:true                          , chunk_size:2     ), d,c,a,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'hash_replicate_right',keep_dimensions:TRUE                          , chunk_size:2     ), d,c,a,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_left_first',    keep_dimensions:TRUE                          , chunk_size:2     ), d,c,a,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_right_first',   keep_dimensions:TRUE                          , chunk_size:2     ), d,c,a,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_left_first',    keep_dimensions:TRUE,  hash_join_threshold:0, chunk_size:2     ), d,c,a,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_right_first',   keep_dimensions:TRUE,  hash_join_threshold:0, chunk_size:2     ), d,c,a,b)" >> $OUTFILE 2>&1
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1                                                                               , chunk_size:2 ), d,c,a,b)"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'hash_replicate_left', keep_dimensions:FALSE                       , chunk_size:2 ), d,c,a,b)"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'hash_replicate_right',keep_dimensions:false                       , chunk_size:2 ), d,c,a,b)"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_left_first',    keep_dimensions:false                       , chunk_size:2 ), d,c,a,b)"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_right_first',   keep_dimensions:false                       , chunk_size:2 ), d,c,a,b)"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_left_first',    keep_dimensions:false, hash_join_threshold:0, chunk_size:2 ), d,c,a,b)"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_right_first',   keep_dimensions:false, hash_join_threshold:0, chunk_size:2 ), d,c,a,b)"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'hash_replicate_left', keep_dimensions:true                        , chunk_size:2 ), d,c,a,b)"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'hash_replicate_right',keep_dimensions:TRUE                        , chunk_size:2 ), d,c,a,b)"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_left_first',    keep_dimensions:TRUE                        , chunk_size:2 ), d,c,a,b)"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_right_first',   keep_dimensions:TRUE                        , chunk_size:2 ), d,c,a,b)"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_left_first',    keep_dimensions:TRUE,  hash_join_threshold:0, chunk_size:2 ), d,c,a,b)"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, algorithm:'merge_right_first',   keep_dimensions:TRUE,  hash_join_threshold:0, chunk_size:2 ), d,c,a,b)"
 
-echo " " >> $OUTFILE 2>&1
+echo >> $OUTFILE 2>&1
 echo "Chapter 23" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c'                                                                     , chunk_size:2                    ))" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c', algorithm:'hash_replicate_left'                                    , chunk_size:2                    ))" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c', algorithm:'hash_replicate_right'                                   , chunk_size:2                    ))" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c', algorithm:'merge_left_first'                                       , chunk_size:2                    ))" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c', algorithm:'merge_right_first'                                      , chunk_size:2                    ))" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c', algorithm:'merge_left_first',     hash_join_threshold:0          , chunk_size:2                    ))" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c', algorithm:'merge_right_first',    hash_join_threshold:0          , chunk_size:2                    ))" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a<>c and j>3', algorithm:'hash_replicate_left', keep_dimensions:1      , chunk_size:2                    ))" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a<>c and j>3', algorithm:'hash_replicate_right',keep_dimensions:1      , chunk_size:2                    ))" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a<>c and j>3', algorithm:'merge_left_first',    keep_dimensions:1      , chunk_size:2                    ))" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a<>c and j>3', algorithm:'merge_right_first',   keep_dimensions:1      , chunk_size:2                    ))" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a<>c and j>3', algorithm:'merge_left_first',    hash_join_threshold:0, keep_dimensions:1, chunk_size:2 ))" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a<>c and j>3', algorithm:'merge_right_first',   hash_join_threshold:0, keep_dimensions:1, chunk_size:2 ))" >> $OUTFILE 2>&1
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c'                                                                   , chunk_size:2                  ))"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c', algorithm:'hash_replicate_left'                                  , chunk_size:2                  ))"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c', algorithm:'hash_replicate_right'                                 , chunk_size:2                  ))"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c', algorithm:'merge_left_first'                                     , chunk_size:2                  ))"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c', algorithm:'merge_right_first'                                    , chunk_size:2                  ))"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c', algorithm:'merge_left_first',     hash_join_threshold:0          , chunk_size:2                  ))"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a=c', algorithm:'merge_right_first',    hash_join_threshold:0          , chunk_size:2                  ))"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a<>c and j>3', algorithm:'hash_replicate_left', keep_dimensions:1      , chunk_size:2                  ))"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a<>c and j>3', algorithm:'hash_replicate_right',keep_dimensions:1      , chunk_size:2                  ))"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a<>c and j>3', algorithm:'merge_left_first',    keep_dimensions:1      , chunk_size:2                  ))"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a<>c and j>3', algorithm:'merge_right_first',   keep_dimensions:1      , chunk_size:2                  ))"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a<>c and j>3', algorithm:'merge_left_first',    hash_join_threshold:0, keep_dimensions:1, chunk_size:2 ))"
+log_query "sort(equi_join(right, left, left_ids:1, right_ids:-1, filter:'a<>c and j>3', algorithm:'merge_right_first',   hash_join_threshold:0, keep_dimensions:1, chunk_size:2 ))"
 
-echo " " >> $OUTFILE 2>&1
+echo >> $OUTFILE 2>&1
 echo "Chapter 24" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_names:(j,c), right_names:(i,a), algorithm:'merge_left_first', keep_dimensions:0, chunk_size:2))"  >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_names:(j,c), right_ids:(-1,0), algorithm:'merge_left_first', keep_dimensions:0,  chunk_size:2 ))"  >> $OUTFILE 2>&1
+log_query "sort(equi_join(right, left, left_names:(j,c), right_names:(i,a), algorithm:'merge_left_first', keep_dimensions:0, chunk_size:2))"
+log_query "sort(equi_join(right, left, left_names:(j,c), right_ids:(-1,0), algorithm:'merge_left_first', keep_dimensions:0,  chunk_size:2 ))"
 
-echo " " >> $OUTFILE 2>&1
+echo >> $OUTFILE 2>&1
 echo "Chapter 25" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, left_outer:true), a,b,d)"  >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, left_outer:true, algorithm:'hash_replicate_right'), a,b,d)"  >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, left_outer:true, algorithm:'merge_left_first'), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, left_outer:true, algorithm:'merge_right_first'), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, left_outer:true, algorithm:'merge_left_first', hash_join_threshold:0), a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, left_outer:true, algorithm:'merge_right_first', hash_join_threshold:0), a,b,d)" >> $OUTFILE 2>&1
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, left_outer:true), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, left_outer:true, algorithm:'hash_replicate_right'), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, left_outer:true, algorithm:'merge_left_first'), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, left_outer:true, algorithm:'merge_right_first'), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, left_outer:true, algorithm:'merge_left_first', hash_join_threshold:0), a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, left_outer:true, algorithm:'merge_right_first', hash_join_threshold:0), a,b,d)"
 
-echo " " >> $OUTFILE 2>&1
+echo >> $OUTFILE 2>&1
 echo "Chapter 26" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, right_outer:true),a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, right_outer:true, algorithm:'hash_replicate_left'),a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, right_outer:true, algorithm:'merge_left_first'),a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, right_outer:true, algorithm:'merge_right_first'),a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, right_outer:true, algorithm:'merge_left_first', hash_join_threshold:0),a,b,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:0, right_ids:0, right_outer:true, algorithm:'merge_right_first', hash_join_threshold:0),a,b,d)" >> $OUTFILE 2>&1
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, right_outer:true),a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, right_outer:true, algorithm:'hash_replicate_left'),a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, right_outer:true, algorithm:'merge_left_first'),a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, right_outer:true, algorithm:'merge_right_first'),a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, right_outer:true, algorithm:'merge_left_first', hash_join_threshold:0),a,b,d)"
+log_query "sort(equi_join(left, right, left_ids:0, right_ids:0, right_outer:true, algorithm:'merge_right_first', hash_join_threshold:0),a,b,d)"
 
-echo " " >> $OUTFILE 2>&1
+echo >> $OUTFILE 2>&1
 echo "Chapter 27" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), left_outer:true, keep_dimensions:1),j,c,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), left_outer:true, keep_dimensions:1, algorithm:'hash_replicate_right'),j,c,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), left_outer:true, keep_dimensions:1, algorithm:'merge_left_first'),j,c,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), left_outer:true, keep_dimensions:1, algorithm:'merge_right_first'),j,c,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), left_outer:true, keep_dimensions:1, algorithm:'merge_left_first', hash_join_threshold:0),j,c,d)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), left_outer:true, keep_dimensions:1, algorithm:'merge_right_first', hash_join_threshold:0),j,c,d)" >> $OUTFILE 2>&1
+log_query "sort(equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), left_outer:true, keep_dimensions:1),j,c,d)"
+log_query "sort(equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), left_outer:true, keep_dimensions:1, algorithm:'hash_replicate_right'),j,c,d)"
+log_query "sort(equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), left_outer:true, keep_dimensions:1, algorithm:'merge_left_first'),j,c,d)"
+log_query "sort(equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), left_outer:true, keep_dimensions:1, algorithm:'merge_right_first'),j,c,d)"
+log_query "sort(equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), left_outer:true, keep_dimensions:1, algorithm:'merge_left_first', hash_join_threshold:0),j,c,d)"
+log_query "sort(equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), left_outer:true, keep_dimensions:1, algorithm:'merge_right_first', hash_join_threshold:0),j,c,d)"
 
-echo " " >> $OUTFILE 2>&1
+echo >> $OUTFILE 2>&1
 echo "Chapter 28" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), right_outer:true, keep_dimensions:1),j,c)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), right_outer:true, keep_dimensions:1, algorithm:'hash_replicate_left'),j,c)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), right_outer:true, keep_dimensions:1, algorithm:'merge_left_first'),j,c)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), right_outer:true, keep_dimensions:1, algorithm:'merge_right_first'),j,c)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), right_outer:true, keep_dimensions:1, algorithm:'merge_left_first', hash_join_threshold:0),j,c)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), right_outer:true, keep_dimensions:1, algorithm:'merge_right_first', hash_join_threshold:0),j,c)" >> $OUTFILE 2>&1
+log_query "sort(equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), right_outer:true, keep_dimensions:1),j,c)"
+log_query "sort(equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), right_outer:true, keep_dimensions:1, algorithm:'hash_replicate_left'),j,c)"
+log_query "sort(equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), right_outer:true, keep_dimensions:1, algorithm:'merge_left_first'),j,c)"
+log_query "sort(equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), right_outer:true, keep_dimensions:1, algorithm:'merge_right_first'),j,c)"
+log_query "sort(equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), right_outer:true, keep_dimensions:1, algorithm:'merge_left_first', hash_join_threshold:0),j,c)"
+log_query "sort(equi_join(right, left, left_ids:(-1,0), right_ids:(-1,0), right_outer:true, keep_dimensions:1, algorithm:'merge_right_first', hash_join_threshold:0),j,c)"
 
-echo " " >> $OUTFILE 2>&1
+echo >> $OUTFILE 2>&1
 echo "Chapter 29" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:(0,-1), right_ids:(0,1), left_outer:1, right_outer:1, keep_dimensions:1, algorithm:'merge_right_first'), a, i,b)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_ids:(0,-1), right_ids:(0,1), left_outer:1, right_outer:1, keep_dimensions:1, algorithm:'merge_left_first'), a, i,b)" >> $OUTFILE 2>&1
+log_query "sort(equi_join(left, right, left_ids:(0,-1), right_ids:(0,1), left_outer:1, right_outer:1, keep_dimensions:1, algorithm:'merge_right_first'), a, i,b)"
+log_query "sort(equi_join(left, right, left_ids:(0,-1), right_ids:(0,1), left_outer:1, right_outer:1, keep_dimensions:1, algorithm:'merge_left_first'), a, i,b)"
 
-echo " " >> $OUTFILE 2>&1
+echo >> $OUTFILE 2>&1
 echo "Chapter 30" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_names:i , right_names:j, left_outer:1, right_outer:1, out_names:(uv,w,x,y_,z)), uv)" >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_names:i, right_names:j, left_outer:1, right_outer:1, algorithm:'merge_left_first'),  i)"  >> $OUTFILE 2>&1
-iquery -aq "sort(equi_join(left, right, left_names:i, right_names:j, left_outer:1, right_outer:1, algorithm:'merge_right_first'), i)"  >> $OUTFILE 2>&1
+log_query "sort(equi_join(left, right, left_names:i, right_names:j, left_outer:1, right_outer:1, out_names:(uv,w,x,y_,z)), uv)"
+log_query "sort(equi_join(left, right, left_names:i, right_names:j, left_outer:1, right_outer:1, algorithm:'merge_left_first'),  i)"
+log_query "sort(equi_join(left, right, left_names:i, right_names:j, left_outer:1, right_outer:1, algorithm:'merge_right_first'), i)"
 
-diff test.out test.expected
+diff test.out test.expected && echo "$(basename $0) succeeded"


### PR DESCRIPTION
This is done by:
(1) removing the instance_id dimension from the output, and
(2) using the shell to sort the output of each unsorted query which might return cells in different orders when running in more than one instance.