### PR TITLE
Fix broken build in SciDB >19.11

### DIFF
--- a/ArrayIO.h
+++ b/ArrayIO.h
@@ -342,7 +342,7 @@ template <Handedness WHICH>
 ArrayDesc makeTupledSchema(Settings const& settings, shared_ptr< Query> const& query)
 {
     size_t const numAttrs = ( WHICH == LEFT ? settings.getLeftTupleSize() : settings.getRightTupleSize()) + 1; //plus hash
-    Attributes outputAttributes(numAttrs);
+    Attributes outputAttributes;
     std::vector<AttributeDesc> tmpOutput(numAttrs);
     tmpOutput[numAttrs-1] = AttributeDesc("hash", TID_UINT32, 0, CompressorType::NONE);
     ArrayDesc const& inputSchema = ( WHICH == LEFT ? settings.getLeftSchema() : settings.getRightSchema());

--- a/EquiJoinSettings.h
+++ b/EquiJoinSettings.h
@@ -927,7 +927,7 @@ public:
 
     ArrayDesc getOutputSchema(shared_ptr< Query> const& query) const
     {
-        Attributes outputAttributes(getNumOutputAttrs());
+        Attributes outputAttributes;
         std::vector<AttributeDesc> tmpOutput(getNumOutputAttrs());
         ArrayDesc const& leftSchema = getLeftSchema();
         size_t const numLeftAttrs = getNumLeftAttrs();

--- a/test.sh
+++ b/test.sh
@@ -3,7 +3,15 @@
 MYDIR=`dirname $0`
 pushd $MYDIR > /dev/null
 MYDIR=`pwd`
-OUTFILE=$MYDIR/test.out
+
+# --outfile <filename> : write iquery output to the given file.
+# This is important for running in the SciDB test harness.
+if [ "$1" = "--outfile" ]; then
+    OUTFILE="$2"
+    shift 2
+else
+    OUTFILE=$MYDIR/test.out
+fi
 EXPFILE=$MYDIR/test.expected
 
 # Use csv:l format instead of the default dcsv, to suppress printing dimensions
@@ -18,7 +26,7 @@ log_query () {
 # Use this to log output of queries that don't sort their output.
 # The output is sorted by the shell before writing to the log file.
 log_unsorted_query () {
-    ( iquery "$FMT" -aq "$1" 2>>$OUTFILE ) | print_header_then sort >> $OUTFILE
+    ( iquery "$FMT" -aq "$1" | print_header_then sort ) >> $OUTFILE 2>&1
 }
 
 # Helper function for log_unsorted_query.


### PR DESCRIPTION
Commit 39b2cf9 in the SciDB repo changed the Attributes constructor and broke
the equi_join build. This commit fixes the constructor usage and should be backward-compatible with SciDB 19.11.

This commit also adds the ability to write test.sh output to an optional parameterized file, which is important for running the test in the SciDB test harness.