### PR TITLE
Fix compiler warnings (unused var and type conversion).

### DIFF
--- a/EquiJoinSettings.h
+++ b/EquiJoinSettings.h
@@ -170,7 +170,8 @@ private:
         for (size_t i = 0; i < content.size(); ++i) {
             size_t val;
             if (content[i] < 0)  // It's a dimension
-                val = shift + abs(content[i] + 1);
+                // labs == abs() for long ints
+                val = shift + labs(content[i] + 1);
             else
                 val = content[i]; // It's an attribute
             keys.push_back(val);
@@ -498,7 +499,6 @@ public:
         _outNames(0)
     {
         string const outNamesHeader                = "out_names=";
-        size_t const nParams = operatorParameters.size();
 
         setKeywordParamInt64(kwParams, KW_LEFT_IDS, &Settings::setParamLeftIds);
         setKeywordParamInt64(kwParams, KW_RIGHT_IDS, &Settings::setParamRightIds);
@@ -933,13 +933,12 @@ public:
         size_t const numLeftAttrs = getNumLeftAttrs();
         size_t const numLeftDims  = getNumLeftDims();
         ArrayDesc const& rightSchema = getRightSchema();
-        size_t const numRightAttrs = getNumRightAttrs();
         size_t const numRightDims  = getNumRightDims();
         size_t i = 0;
         for(const auto& input : _leftSchema.getAttributes(true))
         {
-            AttributeID destinationId = mapLeftToOutput(i);
-            uint16_t flags = input.getFlags();
+            AttributeID destinationId = safe_static_cast<AttributeID>(mapLeftToOutput(i));
+            int16_t flags = input.getFlags();
             if( isRightOuter() || (isLeftKey(i) && isKeyNullable(destinationId)))
             {
                 flags |= AttributeDesc::IS_NULLABLE;
@@ -973,8 +972,8 @@ public:
                 i++;
                 continue;
             }
-            AttributeID destinationId = mapRightToOutput(i);
-            uint16_t flags = input.getFlags();
+            AttributeID destinationId = safe_static_cast<AttributeID>(mapRightToOutput(i));
+            int16_t flags = input.getFlags();
             if(isLeftOuter())
             {
                 flags |= AttributeDesc::IS_NULLABLE;

--- a/JoinHashTable.h
+++ b/JoinHashTable.h
@@ -143,7 +143,7 @@ private:
     size_t const                             _numAttributes;
     size_t const                             _numKeys;
     vector<AttributeComparator>              _keyComparators;
-    size_t const                             _numHashBuckets;
+    uint32_t const                           _numHashBuckets;
     mgd::vector<HashTableEntry*>             _buckets;
     std::vector<Value>                       _values;
     ssize_t                                  _largeValueMemory;
@@ -158,7 +158,7 @@ public:
             _numAttributes(numAttributes),
             _numKeys(_settings.getNumKeys()),
             _keyComparators(_settings.getKeyComparators()),
-            _numHashBuckets(_settings.getNumHashBuckets()),
+            _numHashBuckets(safe_static_cast<uint32_t>(_settings.getNumHashBuckets())),
             _buckets(_arena, _numHashBuckets, NULL),
             _values(0),
             _largeValueMemory(0),
@@ -226,7 +226,7 @@ public:
                 ch += keys[i]->size();
             }
         }
-        return murmur3_32(&buf[0], totalSize);
+        return murmur3_32(&buf[0], safe_static_cast<uint32_t>(totalSize));
     }
 
     uint32_t hashKeys(vector<Value const*> const& keys, size_t const numKeys) const

--- a/PhysicalEquiJoin.cpp
+++ b/PhysicalEquiJoin.cpp
@@ -413,7 +413,7 @@ public:
     {
         ArrayReader<WHICH, READ_INPUT, INCLUDE_NULL_TUPLES> reader(inputArray, settings, chunkFilterToApply, bloomFilterToApply);
         ArrayWriter<WRITE_TUPLED> writer(settings, query, makeTupledSchema<WHICH>(settings, query));
-        size_t const hashMod = settings.getNumHashBuckets();
+        uint32_t const hashMod = safe_static_cast<uint32_t>(settings.getNumHashBuckets());
         vector<char> hashBuf(64);
         size_t const numKeys = settings.getNumKeys();
         Value hashVal;
@@ -439,10 +439,10 @@ public:
     shared_ptr<Array> sortArray(shared_ptr<Array> & inputArray, shared_ptr<Query>& query, Settings const& settings)
     {
         SortingAttributeInfos sortingAttributeInfos(settings.getNumKeys() + 1); //plus hash
-        sortingAttributeInfos[0].columnNo = inputArray->getArrayDesc().getAttributes(true).size()-1;
+        sortingAttributeInfos[0].columnNo = safe_static_cast<int>(inputArray->getArrayDesc().getAttributes(true).size()-1);
         //        sortingAttributeInfos[0].columnNo = inputArray->getArrayDesc().getEmptyBitmapAttribute()->getId();
         sortingAttributeInfos[0].ascent = true;
-        for(size_t k=0; k<settings.getNumKeys(); ++k)
+        for(uint32_t k=0; k<settings.getNumKeys(); ++k)
         {
             sortingAttributeInfos[k+1].columnNo = k;
             sortingAttributeInfos[k+1].ascent = true;
@@ -476,7 +476,6 @@ public:
         ArrayReader<RIGHT, READ_SORTED> rightReader(rightSorted, settings);
         vector<Value> previousLeftKeys(numKeys);
         Coordinate previousRightIdx = -1;
-        uint32_t previousLeftHash;
         size_t const leftTupleSize = settings.getLeftTupleSize();
         size_t const rightTupleSize = settings.getRightTupleSize();
         while(!leftReader.end() && !rightReader.end())


### PR DESCRIPTION
Fix compiler warnings that show up while building in the SciDB build environment.
All warnings are unused variables and type conversion errors.
With this change, the plugin builds with 0 warnings in the SciDB build environment.
Tests run:
- SciDB plugin_tests (checkin and daily.stable.grouped_aggregate)
- equi_join/test.sh
All tests passed.